### PR TITLE
New shortcut: menu button launches the gameSwitcher from MainUI

### DIFF
--- a/src/gameSwitcher/gameSwitcher.c
+++ b/src/gameSwitcher/gameSwitcher.c
@@ -461,7 +461,8 @@ int main(void) {
 	int firstPass = 1;
 	int comboKey = 0;
 	
-	SDL_Surface* video = SDL_SetVideoMode(640,480, 32, SDL_HWSURFACE);
+	// SDL_Surface* video = SDL_SetVideoMode(640,480, 32, SDL_HWSURFACE);
+	SDL_Surface* video = SDL_SetVideoMode(640,480, 32, SDL_HWSURFACE|SDL_DOUBLEBUF);     // activate double buffering to display the UI after MainUI
 	SDL_Surface* screen = SDL_CreateRGBSurface(SDL_HWSURFACE, 640,480, 32, 0,0,0,0);
 
 	
@@ -751,6 +752,8 @@ int main(void) {
 	
 	 
 	SDL_BlitSurface(screen, NULL, video, NULL); 
+	SDL_Flip(video);
+	SDL_BlitSurface(screen, NULL, video, NULL); // two times to manage double buffering from MainUI
 	SDL_Flip(video);
 	
    	SDL_FreeSurface(screen);

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -404,18 +404,28 @@ int main(void) {
                     continue;
                 }
 
-                if (ev.code == HW_BTN_MENU && val == 0) {
-                    if (comboKey == 0 && process_isRunning("retroarch") && check_autosave()) {
-                        if (settings.launcher && !settings.menu_inverted) {
+                if (ev.code == HW_BTN_MENU && val == 0) {   // short press on menu
+                
+                if (comboKey == 0){
+                        pid_t pid;
+                        if (pid = process_searchpid("MainUI")) {
+                            kill(pid, SIGKILL); 
                             temp_flag_set(".trimUIMenu", true);
-                            screenshot_system();
-                            terminate_retroarch();
+                            super_short_pulse();
+                        } 
+                
+                        if (process_isRunning("retroarch") && check_autosave()) {
+                            if (settings.launcher && !settings.menu_inverted) {
+                                temp_flag_set(".trimUIMenu", true);
+                                screenshot_system();
+                                terminate_retroarch();
+                            }
+                            else {
+                                temp_flag_set(".trimUIMenu", false);
+                                terminate_retroarch();
+                            }
                         }
-                        else {
-                            temp_flag_set(".trimUIMenu", false);
-                            terminate_retroarch();
                         }
-                    }
                     comboKey = 0;
                 }
             }
@@ -513,6 +523,7 @@ int main(void) {
                     if (val == REPEAT) {
                         repeat_menu++;
                         if (repeat_menu == REPEAT_SEC(1) && !button_flag) {    // long press on menu
+                            comboKey = 1;  // this will avoid to trigger short press action
                             if (!settings.menu_inverted) {
                                 if (process_isRunning("retroarch")) {
                                     temp_flag_set(".trimUIMenu", false);
@@ -569,3 +580,4 @@ int main(void) {
         elapsed_sec = 0;
     }
 }
+


### PR DESCRIPTION
Short press will now launch gameSwitcher,  works from MainUI only.
Require to enable double buffering on gameSwitcher to display it corretly just after closing MainUI.