### PR TITLE
config.json remove all upcases in "extlist" fields.

### DIFF
--- a/static/packages/Emu/Amstrad - CPC (CrocoDS)/Emu/CPC/config.json
+++ b/static/packages/Emu/Amstrad - CPC (CrocoDS)/Emu/CPC/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"sna|SNA|dsk|DSK|kcr|KCR|bin|BIN|zip|ZIP|7z|7Z"
+"extlist":"sna|dsk|kcr|bin|zip|7z"
 }

--- a/static/packages/Emu/Arcade - Default (MAME 2003-Plus)/Emu/ARCADE/config.json
+++ b/static/packages/Emu/Arcade - Default (MAME 2003-Plus)/Emu/ARCADE/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":1,
 "hidebios":1,
-"extlist":"zip|ZIP"
+"extlist":"zip"
 }

--- a/static/packages/Emu/Atari - 2600 (Stella 2014)/Emu/ATARI/config.json
+++ b/static/packages/Emu/Atari - 2600 (Stella 2014)/Emu/ATARI/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"a26|A26|bin|BIN|zip|ZIP|7z|7Z"
+"extlist":"a26|bin|zip|7z"
 }

--- a/static/packages/Emu/Atari - 5200 (a5200)/Emu/FIFTYTWOHUNDRED/config.json
+++ b/static/packages/Emu/Atari - 5200 (a5200)/Emu/FIFTYTWOHUNDRED/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"a52|A52|zip|ZIP|7z|7Z|bin|BIN"
+"extlist":"a52|zip|7z|bin"
 }

--- a/static/packages/Emu/Atari - 7800 (ProSystem)/Emu/SEVENTYEIGHTHUNDRED/config.json
+++ b/static/packages/Emu/Atari - 7800 (ProSystem)/Emu/SEVENTYEIGHTHUNDRED/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"a78|A78|zip|ZIP"
+"extlist":"a78|zip"
 }

--- a/static/packages/Emu/Atari - Lynx (Handy)/Emu/LYNX/config.json
+++ b/static/packages/Emu/Atari - Lynx (Handy)/Emu/LYNX/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"lnx|LNX|zip|ZIP"
+"extlist":"lnx|zip"
 }

--- a/static/packages/Emu/Bandai - Sufami Turbo (snes9x)/Emu/SUFAMI/config.json
+++ b/static/packages/Emu/Bandai - Sufami Turbo (snes9x)/Emu/SUFAMI/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"smc|SMC|zip|ZIP|7z|7Z"
+"extlist":"smc|zip|7z"
 }

--- a/static/packages/Emu/Bandai - WonderSwanColor (B. Cygne)/Emu/WS/config.json
+++ b/static/packages/Emu/Bandai - WonderSwanColor (B. Cygne)/Emu/WS/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"ws|WS|pc2|PC2|zip|ZIP|7z|7Z"
+"extlist":"ws|pc2|zip|7z"
 }

--- a/static/packages/Emu/Capcom - CPS1 (FB Alpha 2012 CPS-1)/Emu/CPS1/config.json
+++ b/static/packages/Emu/Capcom - CPS1 (FB Alpha 2012 CPS-1)/Emu/CPS1/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":1,
 "hidebios":1,
-"extlist":"zip|ZIP|7z|7Z|cue|CUE"
+"extlist":"zip|7z|cue"
 }

--- a/static/packages/Emu/Capcom - CPS2 (FB Alpha 2012 CPS-2)/Emu/CPS2/config.json
+++ b/static/packages/Emu/Capcom - CPS2 (FB Alpha 2012 CPS-2)/Emu/CPS2/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":1,
 "hidebios":1,
-"extlist":"zip|ZIP|7z|7Z|cue|CUE"
+"extlist":"zip|7z|cue"
 }

--- a/static/packages/Emu/Capcom - CPS3 (FB Alpha 2012 CPS-3)/Emu/CPS3/config.json
+++ b/static/packages/Emu/Capcom - CPS3 (FB Alpha 2012 CPS-3)/Emu/CPS3/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":1,
 "hidebios":1,
-"extlist":"zip|ZIP|7z|7Z|cue|CUE"
+"extlist":"zip|7z|cue"
 }

--- a/static/packages/Emu/Coleco - ColecoVision (blueMSX)/Emu/COLECO/config.json
+++ b/static/packages/Emu/Coleco - ColecoVision (blueMSX)/Emu/COLECO/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"rom|ROM|ri|RI|mx1|MX1|mx2|MX2|col|COL|dsk|DSK|cas|CAS|sg|SG|sc|SC|m3u|M3U|zip|ZIP|7z|7Z"
+"extlist":"rom|ri|mx1|mx2|col|dsk|cas|sg|sc|m3u|zip|7z"
 }

--- a/static/packages/Emu/Commodore - Amiga (puae)/Emu/AMIGA/config.json
+++ b/static/packages/Emu/Commodore - Amiga (puae)/Emu/AMIGA/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"adf|ADF|hdf|HDF|lha|LHA|zip|ZIP|cue|CUE"
+"extlist":"adf|hdf|lha|zip|cue"
 }

--- a/static/packages/Emu/Fairchild - ChannelF (FreeChaF)/Emu/FAIRCHILD/config.json
+++ b/static/packages/Emu/Fairchild - ChannelF (FreeChaF)/Emu/FAIRCHILD/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"bin|BIN|rom|ROM|chf|CHF|zip|ZIP"
+"extlist":"bin|rom|chf|zip"
 }

--- a/static/packages/Emu/GCE - Vectrex (vecx)/Emu/VECTREX/config.json
+++ b/static/packages/Emu/GCE - Vectrex (vecx)/Emu/VECTREX/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"vec|VEC|zip|ZIP|7z|7Z"
+"extlist":"vec|zip|7z"
 }

--- a/static/packages/Emu/Magnavox - Odyssey2 (O2EM)/Emu/ODYSSEY/config.json
+++ b/static/packages/Emu/Magnavox - Odyssey2 (O2EM)/Emu/ODYSSEY/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"bin|BIN"
+"extlist":"bin"
 }

--- a/static/packages/Emu/Mattel - Intellivision (FreeIntv)/Emu/INTELLIVISION/config.json
+++ b/static/packages/Emu/Mattel - Intellivision (FreeIntv)/Emu/INTELLIVISION/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"bin|BIN|int|INT|zip|ZIP|7z|7Z"
+"extlist":"bin|int|zip|7z"
 }

--- a/static/packages/Emu/Mega Duck (SameDuck)/Emu/MEGADUCK/config.json
+++ b/static/packages/Emu/Mega Duck (SameDuck)/Emu/MEGADUCK/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"bin|BIN|zip|ZIP|7z|7Z"
+"extlist":"bin|zip|7z"
 }

--- a/static/packages/Emu/Microsoft - DOS (DOSBox-Pure)/Emu/DOS/config.json
+++ b/static/packages/Emu/Microsoft - DOS (DOSBox-Pure)/Emu/DOS/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"zip|ZIP|dosz|DOSZ|exe|EXE|com|COM|bat|BAT|iso|ISO|ins|INS|img|IMG|ima|IMA|vhd|VHD|jrc|JRC|tc|TC|m3u|M3U|m3u8|M3U8|conf|CONF"
+"extlist":"zip|dosz|exe|com|bat|iso|ins|img|ima|vhd|jrc|tc|m3u|m3u8|conf"
 }

--- a/static/packages/Emu/Microsoft - MSX (blueMSX)/Emu/MSX/config.json
+++ b/static/packages/Emu/Microsoft - MSX (blueMSX)/Emu/MSX/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"rom|ROM|mx1|MX1|mx2|MX2|dsk|DSK|cas|CAS|zip|ZIP|7z|7Z"
+"extlist":"rom|mx1|mx2|dsk|cas|zip|7z"
 }

--- a/static/packages/Emu/NEC - SuperGrafx (Beetle SuperGrafx)/Emu/SGFX/config.json
+++ b/static/packages/Emu/NEC - SuperGrafx (Beetle SuperGrafx)/Emu/SGFX/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"pce|PCE|sgx|SGX|cue|CUE|ccd|CCD|chd|CHD"
+"extlist":"pce|sgx|cue|ccd|chd"
 }

--- a/static/packages/Emu/NEC - TurboGrafx CD (Beetle PCE FAST)/Emu/PCECD/config.json
+++ b/static/packages/Emu/NEC - TurboGrafx CD (Beetle PCE FAST)/Emu/PCECD/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"pce|PCE|ccd|CCD|iso|ISO|img|IMG|chd|CHD|cue|CUE|zip|ZIP|7z|7Z"
+"extlist":"pce|ccd|iso|img|chd|cue|zip|7z"
 }

--- a/static/packages/Emu/NEC - TurboGrafx-16 (Beetle PCE FAST)/Emu/PCE/config.json
+++ b/static/packages/Emu/NEC - TurboGrafx-16 (Beetle PCE FAST)/Emu/PCE/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"pce|PCE|ccd|CCD|iso|ISO|img|IMG|chd|CHD|cue|CUE|zip|ZIP|7z|7Z"
+"extlist":"pce|ccd|iso|img|chd|cue|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Famicom Disk Syst. (FCEUmm)/Emu/FDS/config.json
+++ b/static/packages/Emu/Nintendo - Famicom Disk Syst. (FCEUmm)/Emu/FDS/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":0,
-"extlist":"fds|FDS|nes|NES|unif|UNIF|unf|UNF|zip|ZIP|7z|7Z"
+"extlist":"fds|nes|unif|unf|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Game & Watch (gw)/Emu/GW/config.json
+++ b/static/packages/Emu/Nintendo - Game & Watch (gw)/Emu/GW/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"mgw|MGW|zip|ZIP|7z|7Z"
+"extlist":"mgw|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Game Boy (Gambatte)/Emu/GB/config.json
+++ b/static/packages/Emu/Nintendo - Game Boy (Gambatte)/Emu/GB/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":0,
-"extlist":"bin|BIN|dmg|DMG|gb|GB|gbc|GBC|zip|ZIP|7z|7Z"
+"extlist":"bin|dmg|gb|gbc|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Game Boy Advance (gpSP)/Emu/GBA/config.json
+++ b/static/packages/Emu/Nintendo - Game Boy Advance (gpSP)/Emu/GBA/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"bin|BIN|gba|GBA|zip|ZIP|7z|7Z"
+"extlist":"bin|gba|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Game Boy Color (Gambatte)/Emu/GBC/config.json
+++ b/static/packages/Emu/Nintendo - Game Boy Color (Gambatte)/Emu/GBC/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":0,
-"extlist":"bin|BIN|dmg|DMG|gb|GB|gbc|GBC|zip|ZIP|7z|7Z"
+"extlist":"bin|dmg|gb|gbc|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - NES (FCEUmm)/Emu/FC/config.json
+++ b/static/packages/Emu/Nintendo - NES (FCEUmm)/Emu/FC/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"fds|FDS|nes|NES|unif|UNIF|unf|UNF|zip|ZIP|7z|7Z"
+"extlist":"fds|nes|unif|unf|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Pokemon Mini (PokeMini)/Emu/POKE/config.json
+++ b/static/packages/Emu/Nintendo - Pokemon Mini (PokeMini)/Emu/POKE/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"min|MIN|zip|ZIP"
+"extlist":"min|zip"
 }

--- a/static/packages/Emu/Nintendo - SNES (Beetle Supafaust)/Emu/SFC/config.json
+++ b/static/packages/Emu/Nintendo - SNES (Beetle Supafaust)/Emu/SFC/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"sfc|SFC|smc|SMC|fig|FIG|bs|BS|st|ST|zip|ZIP|7z|7Z"
+"extlist":"sfc|smc|fig|bs|st|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Satellaview (Snes9x)/Emu/SATELLAVIEW/config.json
+++ b/static/packages/Emu/Nintendo - Satellaview (Snes9x)/Emu/SATELLAVIEW/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"bs|BS|sfc|SFC|smc|SMC|swc|SWC|fig|FIG|st|ST|zip|ZIP|7z|7Z"
+"extlist":"bs|sfc|smc|swc|fig|st|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Super Game Boy (mGBA)/Emu/SGB/config.json
+++ b/static/packages/Emu/Nintendo - Super Game Boy (mGBA)/Emu/SGB/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"bin|BIN|gb|GB|gbc|GBC|gba|GBA|zip|ZIP|7z|7Z"
+"extlist":"bin|gb|gbc|gba|zip|7z"
 }

--- a/static/packages/Emu/Nintendo - Virtual Boy (Beetle VB)/Emu/VB/config.json
+++ b/static/packages/Emu/Nintendo - Virtual Boy (Beetle VB)/Emu/VB/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"vb|VB|vboy|VBOY|zip|ZIP|7z|7Z"
+"extlist":"vb|vboy|zip|7z"
 }

--- a/static/packages/Emu/Phillips - Videopac+ (O2EM)/Emu/VIDEOPAC/config.json
+++ b/static/packages/Emu/Phillips - Videopac+ (O2EM)/Emu/VIDEOPAC/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"bin|BIN|zip|ZIP|7z|7Z"
+"extlist":"bin|zip|7z"
 }

--- a/static/packages/Emu/SCUMM (ScummVM)/Emu/SCUMMVM/config.json
+++ b/static/packages/Emu/SCUMM (ScummVM)/Emu/SCUMMVM/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"scummvm|SCUMMVM"
+"extlist":"scummvm"
 }

--- a/static/packages/Emu/SNK - Neo Geo (fbalpha2012 neogeo)/Emu/NEOGEO/config.json
+++ b/static/packages/Emu/SNK - Neo Geo (fbalpha2012 neogeo)/Emu/NEOGEO/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":1,
 "hidebios":1,
-"extlist":"zip|ZIP|7z|7Z"
+"extlist":"zip|7z"
 }

--- a/static/packages/Emu/SNK - Neo Geo CD (NeoCD)/Emu/NEOCD/config.json
+++ b/static/packages/Emu/SNK - Neo Geo CD (NeoCD)/Emu/NEOCD/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"iso|ISO|img|IMG|bin|BIN|chd|CHD"
+"extlist":"iso|img|bin|chd"
 }

--- a/static/packages/Emu/SNK - Neo Geo Pocket Color (B. NeoPop)/Emu/NGP/config.json
+++ b/static/packages/Emu/SNK - Neo Geo Pocket Color (B. NeoPop)/Emu/NGP/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":0,
-"extlist":"ngp|NGP|ngc|NGC|zip|ZIP|7z|7Z"
+"extlist":"ngp|ngc|zip|7z"
 }

--- a/static/packages/Emu/Sega - 32X (PicoDrive)/Emu/THIRTYTWOX/config.json
+++ b/static/packages/Emu/Sega - 32X (PicoDrive)/Emu/THIRTYTWOX/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"gen|GEN|smd|SMD|md|MD|32x|32X|cue|CUE|iso|ISO|sms|SMS|68k|68K|chd|CHD|zip|ZIP|7z|7Z"
+"extlist":"gen|smd|md|32x|cue|iso|sms|68k|chd|zip|7z"
 }

--- a/static/packages/Emu/Sega - CD (PicoDrive)/Emu/SEGACD/config.json
+++ b/static/packages/Emu/Sega - CD (PicoDrive)/Emu/SEGACD/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"gen|GEN|smd|SMD|md|MD|32x|32X|cue|CUE|iso|ISO|sms|SMS|68k|68K|chd|CHD|zip|ZIP|7z|7Z"
+"extlist":"gen|smd|md|32x|cue|iso|sms|68k|chd|zip|7z"
 }

--- a/static/packages/Emu/Sega - Game Gear (PicoDrive)/Emu/GG/config.json
+++ b/static/packages/Emu/Sega - Game Gear (PicoDrive)/Emu/GG/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":"bin|BIN|gg|GG|zip|ZIP|7z|7Z"
+"extlist":"bin|gg|zip|7z"
 }

--- a/static/packages/Emu/Sega - Genesis (PicoDrive)/Emu/MD/config.json
+++ b/static/packages/Emu/Sega - Genesis (PicoDrive)/Emu/MD/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"gen|GEN|smd|SMD|md|MD|32x|32X|bin|BIN|iso|ISO|sms|SMS|68k|68K|chd|CHD|zip|ZIP|7z|7Z"
+"extlist":"gen|smd|md|32x|bin|iso|sms|68k|chd|zip|7z"
 }

--- a/static/packages/Emu/Sega - Master System (PicoDrive)/Emu/MS/config.json
+++ b/static/packages/Emu/Sega - Master System (PicoDrive)/Emu/MS/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":0,
-"extlist":"gen|GEN|smd|SMD|md|MD|32x|32X|cue|CUE|iso|ISO|sms|SMS|68k|68K|chd|CHD|zip|ZIP|7z|7Z"
+"extlist":"gen|smd|md|32x|cue|iso|sms|68k|chd|zip|7z"
 }

--- a/static/packages/Emu/Sega - SG-1000 (Gearsystem)/Emu/SEGASGONE/config.json
+++ b/static/packages/Emu/Sega - SG-1000 (Gearsystem)/Emu/SEGASGONE/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":0,
-"extlist":"sms|SMS|gg|GG|sg|SG|mv|MV|bin|BIN|rom|ROM|zip|ZIP|7z|7Z"
+"extlist":"sms|gg|sg|mv|bin|rom|zip|7z"
 }

--- a/static/packages/Emu/Sinclair - ZX Spectrum (Fuse)/Emu/ZXS/config.json
+++ b/static/packages/Emu/Sinclair - ZX Spectrum (Fuse)/Emu/ZXS/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"tzx|TZX|tap|TAP|z80|Z80|rzx|RZX|scl|SCL|trd|TRD|zip|ZIP|7z|7Z"
+"extlist":"tzx|tap|z80|rzx|scl|trd|zip|7z"
 }

--- a/static/packages/Emu/Sony - PlayStation (PCSX ReARMed)/Emu/PSX/config.json
+++ b/static/packages/Emu/Sony - PlayStation (PCSX ReARMed)/Emu/PSX/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"cue|CUE|mdf|MDF|pbp|PBP|toc|TOC|cbn|CBN|m3u|M3U|ccd|CCD|chd|CHD"
+"extlist":"cue|mdf|pbp|toc||cbn|m3u|ccd|chd"
 }

--- a/static/packages/Emu/TIC-80 (TIC-80)/Emu/TIC/config.json
+++ b/static/packages/Emu/TIC-80 (TIC-80)/Emu/TIC/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"tic|TIC|fd|FD|sap|SAP|k7|K7|m7|M7|rom|ROM|zip|ZIP|7z|7Z"
+"extlist":"tic|fd|sap|k7|m7|rom|zip|7z"
 }

--- a/static/packages/Emu/Watara - Supervision (Potator)/Emu/SUPERVISION/config.json
+++ b/static/packages/Emu/Watara - Supervision (Potator)/Emu/SUPERVISION/config.json
@@ -9,5 +9,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":0,
-"extlist":"sv|SV|bin|BIN|zip|ZIP|7z|7Z"
+"extlist":"sv|bin|zip|7z"
 }

--- a/static/packages/RApp/.Arcade (Final Burn Alpha)/RApp/ARCADE/config.json
+++ b/static/packages/RApp/.Arcade (Final Burn Alpha)/RApp/ARCADE/config.json
@@ -8,5 +8,5 @@
 "useswap":1,
 "shortname":1,
 "hidebios":1,
-"extlist":"zip|ZIP|7z|7Z|cue|CUE"
+"extlist":"zip|7z|cue"
 }

--- a/static/packages/RApp/Arcade (MAME 2003-xtreme)/RApp/mame2003-xtreme/config.json
+++ b/static/packages/RApp/Arcade (MAME 2003-xtreme)/RApp/mame2003-xtreme/config.json
@@ -9,5 +9,5 @@
 "useswap":1,
 "shortname":1,
 "hidebios":1,
-"extlist":"zip|ZIP|7z|7Z|cue|CUE"
+"extlist":"zip|7z|cue"
 }

--- a/static/packages/RApp/Nintendo - GBA (mGBA)/RApp/mgba/config.json
+++ b/static/packages/RApp/Nintendo - GBA (mGBA)/RApp/mgba/config.json
@@ -8,5 +8,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":1,
-"extlist":"bin|BIN|gb|GB|gbc|GBC|gba|GBA|zip|ZIP|7z|7Z"
+"extlist":"bin|gb|gbc|gba|zip|7z"
 }

--- a/static/packages/RApp/Nintendo - SNES (Snes9x 2005 Plus/RApp/SNES9X2005P/config.json
+++ b/static/packages/RApp/Nintendo - SNES (Snes9x 2005 Plus/RApp/SNES9X2005P/config.json
@@ -8,5 +8,5 @@
 "useswap":1,
 "shortname":0,
 "hidebios":0,
-"extlist":"sfc|SFC|smc|SMC|zip|ZIP|7z|7Z"
+"extlist":"sfc|smc|zip|7z"
 }


### PR DESCRIPTION
MainUI read each config.json "extlist" fields and filter roms lists. This feature of MainUI is not key sensitive so we delete all upcases doublons.