### PR TITLE
Fixed mute and added mute toggle for MMP

### DIFF
--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -60,7 +60,7 @@ void _settings_reset(void)
     // MainUI settings
     settings.volume = 20;
     strcpy(settings.keymap, "L2,L,R2,R,X,A,B,Y");
-    settings.mute = 1;
+    settings.mute = 0;
     settings.bgm_volume = 20;
     settings.brightness = 7;
     strcpy(settings.language, "en.lang");
@@ -284,6 +284,24 @@ void settings_setBrightness(uint32_t value, bool apply, bool save)
         cJSON *request_json = json_load(MAIN_UI_SETTINGS);
         cJSON *itemBrightness = cJSON_GetObjectItem(request_json, "brightness");
         cJSON_SetNumberValue(itemBrightness, settings.brightness);
+        json_save(request_json, MAIN_UI_SETTINGS);
+        cJSON_free(request_json);
+        FILE *fp;
+        file_put_sync(fp, "/tmp/settings_changed", "%s", "");
+    }
+}
+
+void settings_setMute(bool mute, bool apply, bool save)
+{
+    settings.mute = mute;
+
+    if (apply)
+        setMute(mute);
+
+    if (save) {
+        cJSON *request_json = json_load(MAIN_UI_SETTINGS);
+        cJSON *itemMute = cJSON_GetObjectItem(request_json, "mute");
+        cJSON_SetNumberValue(itemMute, settings.mute);
         json_save(request_json, MAIN_UI_SETTINGS);
         cJSON_free(request_json);
         FILE *fp;

--- a/src/common/system/volume.h
+++ b/src/common/system/volume.h
@@ -8,6 +8,7 @@
 
 #define MI_AO_SETVOLUME 0x4008690b
 #define MI_AO_GETVOLUME 0xc008690c
+#define MI_AO_SETMUTE 0x4008690d
 
 // Increments between -60 and 0
 int setVolumeRaw(int volume, int add)
@@ -49,4 +50,15 @@ int setVolume(int volume, int add)
     return (int)((recent_volume / 3) + 20);
 }
 
+void setMute(bool mute)
+{
+    int fd = open("/dev/mi_ao", O_RDWR);
+    if (fd >= 0) {
+        int buf2[] = {0, mute};
+        uint64_t buf1[] = {sizeof(buf2), (uintptr_t)buf2};
+
+        ioctl(fd, MI_AO_SETMUTE, buf1);
+        close(fd);
+    }
+}
 #endif // VOLUME_H__

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -248,7 +248,7 @@ void suspend_exec(int timeout)
     }
     display_on();
     display_setBrightness(settings.brightness);
-    setVolume(recent_volume, 0);
+    setVolumeRaw(recent_volume, 0);
     if (!killexit) {
         resume();
         system_clock_pause(false);

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -191,6 +191,8 @@ void suspend_exec(int timeout)
     suspend(0);
     rumble(0);
     int recent_volume = setVolumeRaw(-60, 0);
+    if (DEVICE_ID == MIYOO354)
+        setMute(true);
     display_setBrightnessRaw(0);
     display_off();
     system_powersave_on();
@@ -249,6 +251,8 @@ void suspend_exec(int timeout)
     display_on();
     display_setBrightness(settings.brightness);
     setVolumeRaw(recent_volume, 0);
+    if (DEVICE_ID == MIYOO354)
+        setMute(settings.mute);
     if (!killexit) {
         resume();
         system_clock_pause(false);
@@ -338,6 +342,7 @@ int main(void)
         setVolume(20, 0);
     }
     else if (DEVICE_ID == MIYOO354) {
+        setMute(settings.mute);
         setVolume(settings.volume, 0);
     }
 
@@ -532,22 +537,22 @@ int main(void)
                         if (settings.volume <= MAX_VOLUME - VOLUME_INCREMENTS) {
                             settings_setVolume(0, VOLUME_INCREMENTS, true,
                                                true);
+                            settings_setMute(false, true, true);
                             settings_sync();
                         }
                     }
                     break;
                 case HW_BTN_VOLUME_DOWN:
                     volDown_pressed = (val == PRESSED);
-                    if (val == PRESSED) {
+                    if (comboKey_menu && val == PRESSED)
+                        settings_setMute(!settings.mute, true, true);
+                    else if ((val == PRESSED) || (val == REPEAT)) {
                         if (settings.volume >= VOLUME_INCREMENTS) {
                             settings_setVolume(0, -VOLUME_INCREMENTS, true,
                                                true);
+                            settings_setMute(settings.volume == 0, true, true);
                             settings_sync();
                         }
-                    }
-                    else if (val == REPEAT) {
-                        settings_setVolume(0, 0, true, true);
-                        settings_sync();
                     }
                     break;
                 default:


### PR DESCRIPTION
- Fixed: The Miyoo Mini Plus will go fully mute and no longer emit sound quietly when you turn the volume all the way down.
- New: On the Miyoo Mini Plus, press Menu + Vol Down to toggle mute without affecting the saved volume.

Mute state is persistent across device restarts. Changing the volume with the hardware buttons will also unmute the device.

Tested on both the MMP and original Mini, which works the same as before.