### PR TITLE
fix(nl-lang-short): translate "no thumbnail" to dutch

### DIFF
--- a/static/build/miyoo/app/lang/nl.lang.short
+++ b/static/build/miyoo/app/lang/nl.lang.short
@@ -10,7 +10,7 @@
 	"96":	"Terug naar menu",
 	"97":	"State %d/%d",
 	"98":	"Leeg",
-	"99":	"No thumbnail",
+	"99":	"Geen thumbnail",
 	"100":	"Laden mislukt",
 	"101":	"Opslaan mislukt",
 	"102":	"Slot %d opgeslagen",


### PR DESCRIPTION
This translates "No thumbnail" to "Geen thumbnail"