### PR TITLE
Add TGB Dual GBC into Package Manager

### DIFF
--- a/static/packages/RApp/Nintendo - GB (TGB Dual)/RApp/TGB_Dual/config.json
+++ b/static/packages/RApp/Nintendo - GB (TGB Dual)/RApp/TGB_Dual/config.json
@@ -8,5 +8,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":""
+"extlist":"bin|dmg|gb|gbc|zip|7z|cgb"
 }

--- a/static/packages/RApp/Nintendo - GBC (TGB Dual)/RApp/TGB_Dual_gbc/config.json
+++ b/static/packages/RApp/Nintendo - GBC (TGB Dual)/RApp/TGB_Dual_gbc/config.json
@@ -1,0 +1,12 @@
+{
+"label":"TGB Dual_gbc",
+"icon":"../../Icons/Default/rapp/TGB_Dual.png",
+"iconsel":"../../Icons/Default/rapp/TGB_Dual.png",
+"launch":"launch.sh",
+"rompath":"../../Roms/GBC",
+"imgpath":"../../Roms/GBC/Imgs",
+"useswap":0,
+"shortname":0,
+"hidebios":1,
+"extlist":""
+}

--- a/static/packages/RApp/Nintendo - GBC (TGB Dual)/RApp/TGB_Dual_gbc/config.json
+++ b/static/packages/RApp/Nintendo - GBC (TGB Dual)/RApp/TGB_Dual_gbc/config.json
@@ -8,5 +8,5 @@
 "useswap":0,
 "shortname":0,
 "hidebios":1,
-"extlist":""
+"extlist":"bin|dmg|gb|gbc|zip|7z|cgb"
 }

--- a/static/packages/RApp/Nintendo - GBC (TGB Dual)/RApp/TGB_Dual_gbc/launch.sh
+++ b/static/packages/RApp/Nintendo - GBC (TGB Dual)/RApp/TGB_Dual_gbc/launch.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo $0 $*
+progdir=`dirname "$0"`
+homedir=`dirname "$1"`
+
+cd /mnt/SDCARD/RetroArch/
+HOME=/mnt/SDCARD/RetroArch/ $progdir/../../RetroArch/retroarch -v -L $progdir/../../RetroArch/.retroarch/cores/tgbdual_libretro.so "$1"


### PR DESCRIPTION
Hi, i'm new and would like to contribute to this amazing Onion OS!

I found out with the new 4.2 beta we have the TGB Dual in Expert section of Package Manager but it only load `.gb` file
Excited enough to try out `.gbc` games with multiplayer, thus I manually duplicate another folder that points to GBC roms folder too, would it be feasible?
