### PR TITLE
Add static code analysis tool to the build process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Install SDL libs
       run: |
-        sudo apt-get update && sudo apt-get install libsdl1.2-dev libsdl-image1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev
+        sudo apt-get update && sudo apt-get install libsdl1.2-dev libsdl-image1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev cppcheck
     - name: Install gtest manually
       run: |
         sudo apt-get install build-essential libgtest-dev cmake
@@ -28,6 +28,9 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
+    - name: Run static analysis
+      run: |
+        make static-analysis
     - name: Test
       shell: bash
       run: |

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ PACKAGES_EMU_DEST   := $(PACKAGES_DIR)/Emu
 PACKAGES_APP_DEST   := $(PACKAGES_DIR)/App
 PACKAGES_RAPP_DEST  := $(PACKAGES_DIR)/RApp
 TEMP_DIR            := $(ROOT_DIR)/cache/temp
+INCLUDE_DIR         := $(ROOT_DIR)/include
 ifeq (,$(GTEST_INCLUDE_DIR))
 GTEST_INCLUDE_DIR = /usr/include/
 endif
@@ -249,6 +250,9 @@ test:
 	@mkdir -p $(BUILD_TEST_DIR)/infoPanel_test_data && cd $(TEST_SRC_DIR) && BUILD_DIR=$(BUILD_TEST_DIR)/ make dev
 	@cp -R $(TEST_SRC_DIR)/infoPanel_test_data $(BUILD_TEST_DIR)/
 	cd $(BUILD_TEST_DIR) && ./test
+
+static-analysis:
+	@cd $(ROOT_DIR) && cppcheck -I $(INCLUDE_DIR) --enable=all $(SRC_DIR)
 
 format:
 	@find ./src -regex '.*\.\(c\|h\|cpp\|hpp\)' -exec clang-format -style=file -i {} \;


### PR DESCRIPTION
Attempting small implementation for #85, highly looking forward to any feedback or requested changes.

- Added `static-analysis` make target
- Added static analysis step to `test.yml` GitHub pipeline. The same will not fail the build currently, this can be reassessed once the static code report is further reviewed