### PR TITLE
Fix: The long delay in/out of Tweaks when network services changed

### DIFF
--- a/static/build/.tmp_update/script/update_networking.sh
+++ b/static/build/.tmp_update/script/update_networking.sh
@@ -283,6 +283,7 @@ check_tzid() {
 check_ntpstate() { 
     if flag_enabled NTPState && wifi_enabled; then
         current_tz=$(check_tzid)
+		ntpdate time.google.com &
         if [ "$current_tz" != "$old_tz" ]; then
             export old_tz="$current_tz"
             restart_ntp &
@@ -294,7 +295,7 @@ restart_ntp() {
     export old_tz=$(check_tzid)
     set_tzid
     log "NTP: Starting NTP with TZ of $TZ"
-    ntpdate time.google.com
+    ntpdate time.google.com &
     hwclock -w
 	touch /tmp/time_update
 	sync
@@ -334,7 +335,6 @@ set_tzid() {
 }
 
 set_tzid
-ntpdate time.google.com
 
 is_signup_enabled() { # Used to check signup val for HTTPFS
     DB_PATH="/mnt/SDCARD/.tmp_update/bin/filebrowser/filebrowser.db"


### PR DESCRIPTION
This was caused by NTP not being backgrounded - it was called in by update_networking.sh to update the time but in the wrong place, so when the state of a toggle was changed ntpdate ran but in the FG instead of BG, when the process dies the UI frees up.

- Moved ntp into the check_ntpstate func, it runs often (when network state is changed in tweaks) but this will ensure time is kept closely in line with NTP, it's a self terminating process so won't hang around long.

- Backgrounded 2 calls of ntp