### PR TITLE
Improve memory leak in InstallUI

### DIFF
--- a/src/common/utils/imageCache.c
+++ b/src/common/utils/imageCache.c
@@ -29,7 +29,6 @@ static void *_imageCacheThread(void *param)
         offset = images_total - image_cache_len;
     if (offset < 0)
         offset = 0;
-
     for (int i = 0; i < image_cache_len; i++) {
         int curr = offset + i;
 
@@ -47,7 +46,6 @@ static void *_imageCacheThread(void *param)
         if (load_image != NULL)
             image_cache[idx] = load_image(curr);
     }
-
     image_cache_offset = offset + image_cache_len - 1;
 
     thread_active = false;

--- a/src/installUI/installUI.c
+++ b/src/installUI/installUI.c
@@ -162,6 +162,7 @@ int main(int argc, char *argv[])
 
         if (ticks - slide_timer > SLIDE_TIMEOUT) {
             current_slide = nextSlide(current_slide, num_slides, 1);
+            slide = current_slide == -1 ? NULL : imageCache_getItem(&current_slide);
             slide_timer = ticks;
         }
 

--- a/src/installUI/installUI.c
+++ b/src/installUI/installUI.c
@@ -89,7 +89,8 @@ int main(int argc, char *argv[])
 
     SDL_Surface *waiting_bg = IMG_Load("res/waitingBG.png");
     SDL_Surface *progress_stripes = IMG_Load("res/progress_stripes.png");
-
+    SDL_Surface *slide = NULL;
+    
     TTF_Font *font = TTF_OpenFont("/customer/app/Exo-2-Bold-Italic.ttf", 36);
     TTF_Font *font_small =
         TTF_OpenFont("/customer/app/Exo-2-Bold-Italic.ttf", 18);
@@ -106,7 +107,7 @@ int main(int argc, char *argv[])
     Uint32 progress_color = SDL_MapRGB(video->format, 114, 71, 194);
     Uint32 failed_color = SDL_MapRGB(video->format, 194, 71, 71);
 
-    SDL_Rect rectMessage = {10, 414};
+    SDL_Rect rectMessage = {10, 418};
     SDL_Rect rectProgress = {0, 470, 0, 10};
     SDL_Rect stripes_pos = {0, 470};
     SDL_Rect stripes_frame = {0, 0, 640, 10};
@@ -127,7 +128,6 @@ int main(int argc, char *argv[])
     uint32_t acc_ticks = 0, last_ticks = SDL_GetTicks(),
              time_step = 1000 / 24, // 12 fps
         check_timer = 0;
-
     uint32_t slide_timer = last_ticks;
 
     while (!quit) {
@@ -142,10 +142,12 @@ int main(int argc, char *argv[])
                 switch (event.key.keysym.sym) {
                 case SW_BTN_LEFT:
                     current_slide = nextSlide(current_slide, num_slides, -1);
+                    slide = current_slide == -1 ? NULL : imageCache_getItem(&current_slide);
                     slide_timer = ticks;
                     break;
                 case SW_BTN_RIGHT:
                     current_slide = nextSlide(current_slide, num_slides, 1);
+                    slide = current_slide == -1 ? NULL : imageCache_getItem(&current_slide);
                     slide_timer = ticks;
                     break;
                 case SW_BTN_A:
@@ -197,8 +199,6 @@ int main(int argc, char *argv[])
             break;
 
         if (acc_ticks >= time_step) {
-            SDL_Surface *slide =
-                current_slide == -1 ? NULL : imageCache_getItem(&current_slide);
             if (slide == NULL)
                 SDL_BlitSurface(waiting_bg, NULL, screen, NULL);
             else


### PR DESCRIPTION
Moved the loading of slides out of the main loop into the key press and SLIDE_TIMEOUT checks.
Before, they were loaded every 15 msec by the main loop.

This addresses #929 