### PR TITLE
Add toggle for disabling standby (instant shutdown)

### DIFF
--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -61,6 +61,7 @@ static struct settings_s {
     int ingame_single_press;
     int ingame_long_press;
     int ingame_double_press;
+    bool disable_standby;
 
     char mainui_button_x[JSON_STRING_LEN];
     char mainui_button_y[JSON_STRING_LEN];
@@ -116,6 +117,7 @@ void _settings_reset(void)
     settings.ingame_single_press = 1;
     settings.ingame_long_press = 2;
     settings.ingame_double_press = 3;
+    settings.disable_standby = false;
     memset(settings.mainui_button_x, 0, JSON_STRING_LEN);
     memset(settings.mainui_button_y, 0, JSON_STRING_LEN);
 }
@@ -189,6 +191,7 @@ void settings_load(void)
     settings.auth_http_state = config_flag_get(".authhttpState");
     settings.auth_ssh_state = config_flag_get(".authsshState");
     settings.mute = config_flag_get(".muteVolume");
+    settings.disable_standby = config_flag_get(".disableStandby");
 
     if (config_flag_get(
             ".noBatteryWarning")) // flag is deprecated, but keep compatibility
@@ -303,6 +306,7 @@ void settings_save(void)
     config_flag_set(".authhttpState", settings.auth_http_state);
     config_flag_set(".authsshState", settings.auth_ssh_state);
     config_flag_set(".muteVolume", settings.mute);
+    config_flag_set(".disableStandby",settings.disable_standby);
     config_setNumber("tzselect", settings.tzselect_state);
     config_setNumber("battery/warnAt", settings.low_battery_warn_at);
     config_setNumber("startup/app", settings.startup_application);

--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -61,7 +61,7 @@ static struct settings_s {
     int ingame_single_press;
     int ingame_long_press;
     int ingame_double_press;
-    bool power_single_press;
+    bool disable_standby;
 
     char mainui_button_x[JSON_STRING_LEN];
     char mainui_button_y[JSON_STRING_LEN];
@@ -117,7 +117,7 @@ void _settings_reset(void)
     settings.ingame_single_press = 1;
     settings.ingame_long_press = 2;
     settings.ingame_double_press = 3;
-    settings.power_single_press = false;
+    settings.disable_standby = false;
     memset(settings.mainui_button_x, 0, JSON_STRING_LEN);
     memset(settings.mainui_button_y, 0, JSON_STRING_LEN);
 }
@@ -191,7 +191,7 @@ void settings_load(void)
     settings.auth_http_state = config_flag_get(".authhttpState");
     settings.auth_ssh_state = config_flag_get(".authsshState");
     settings.mute = config_flag_get(".muteVolume");
-    settings.power_single_press = config_flag_get(".powerSinglePress");
+    settings.disable_standby = config_flag_get(".disableStandby");
 
     if (config_flag_get(
             ".noBatteryWarning")) // flag is deprecated, but keep compatibility
@@ -306,7 +306,7 @@ void settings_save(void)
     config_flag_set(".authhttpState", settings.auth_http_state);
     config_flag_set(".authsshState", settings.auth_ssh_state);
     config_flag_set(".muteVolume", settings.mute);
-    config_flag_set(".powerSinglePress",settings.power_single_press);
+    config_flag_set(".disableStandby",settings.disable_standby);
     config_setNumber("tzselect", settings.tzselect_state);
     config_setNumber("battery/warnAt", settings.low_battery_warn_at);
     config_setNumber("startup/app", settings.startup_application);

--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -61,7 +61,7 @@ static struct settings_s {
     int ingame_single_press;
     int ingame_long_press;
     int ingame_double_press;
-    bool disable_standby;
+    bool power_single_press;
 
     char mainui_button_x[JSON_STRING_LEN];
     char mainui_button_y[JSON_STRING_LEN];
@@ -117,7 +117,7 @@ void _settings_reset(void)
     settings.ingame_single_press = 1;
     settings.ingame_long_press = 2;
     settings.ingame_double_press = 3;
-    settings.disable_standby = false;
+    settings.power_single_press = false;
     memset(settings.mainui_button_x, 0, JSON_STRING_LEN);
     memset(settings.mainui_button_y, 0, JSON_STRING_LEN);
 }
@@ -191,7 +191,7 @@ void settings_load(void)
     settings.auth_http_state = config_flag_get(".authhttpState");
     settings.auth_ssh_state = config_flag_get(".authsshState");
     settings.mute = config_flag_get(".muteVolume");
-    settings.disable_standby = config_flag_get(".disableStandby");
+    settings.power_single_press = config_flag_get(".powerSinglePress");
 
     if (config_flag_get(
             ".noBatteryWarning")) // flag is deprecated, but keep compatibility
@@ -306,7 +306,7 @@ void settings_save(void)
     config_flag_set(".authhttpState", settings.auth_http_state);
     config_flag_set(".authsshState", settings.auth_ssh_state);
     config_flag_set(".muteVolume", settings.mute);
-    config_flag_set(".disableStandby",settings.disable_standby);
+    config_flag_set(".powerSinglePress",settings.power_single_press);
     config_setNumber("tzselect", settings.tzselect_state);
     config_setNumber("battery/warnAt", settings.low_battery_warn_at);
     config_setNumber("startup/app", settings.startup_application);

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -409,7 +409,7 @@ int main(void)
                 if (!comboKey_menu && val == REPEAT) {
                     repeat_power++;
                     if (repeat_power == 7)
-                        if(!settings.disable_standby)
+                        if(!settings.power_single_press)
                             deepsleep(); // 0.5sec deepsleep
                     else if (repeat_power == REPEAT_SEC(5)) {
                         short_pulse();
@@ -428,7 +428,7 @@ int main(void)
                         if (comboKey_menu)
                             takeScreenshot();
                         else{
-                            if(settings.disable_standby){
+                            if(settings.power_single_press){
                                 deepsleep();
                             } else{
                                 turnOffScreen();

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -409,7 +409,8 @@ int main(void)
                 if (!comboKey_menu && val == REPEAT) {
                     repeat_power++;
                     if (repeat_power == 7)
-                        deepsleep(); // 0.5sec deepsleep
+                        if(!settings.disable_standby)
+                            deepsleep(); // 0.5sec deepsleep
                     else if (repeat_power == REPEAT_SEC(5)) {
                         short_pulse();
                         remove(CMD_TO_RUN_PATH);
@@ -426,8 +427,13 @@ int main(void)
                     if (power_pressed && repeat_power < 7) {
                         if (comboKey_menu)
                             takeScreenshot();
-                        else
-                            turnOffScreen();
+                        else{
+                            if(settings.disable_standby){
+                                deepsleep();
+                            } else{
+                                turnOffScreen();
+                            }
+                        }
                     }
                     power_pressed = false;
                 }

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -409,7 +409,7 @@ int main(void)
                 if (!comboKey_menu && val == REPEAT) {
                     repeat_power++;
                     if (repeat_power == 7)
-                        if(!settings.power_single_press)
+                        if(!settings.disable_standby)
                             deepsleep(); // 0.5sec deepsleep
                     else if (repeat_power == REPEAT_SEC(5)) {
                         short_pulse();
@@ -428,7 +428,7 @@ int main(void)
                         if (comboKey_menu)
                             takeScreenshot();
                         else{
-                            if(settings.power_single_press){
+                            if(settings.disable_standby){
                                 deepsleep();
                             } else{
                                 turnOffScreen();

--- a/src/tweaks/actions.h
+++ b/src/tweaks/actions.h
@@ -72,9 +72,9 @@ void action_setLowBatteryAutoSave(void *pt)
     settings.low_battery_autosave = ((ListItem *)pt)->value == 1;
 }
 
-void action_setPowerSinglePress(void *pt)
+void action_setDisableStandby(void *pt)
 {
-    settings.power_single_press = ((ListItem *)pt)->value == 1;
+    settings.disable_standby = ((ListItem *)pt)->value == 1;
 }
 
 void action_sethttpstate(void *pt)

--- a/src/tweaks/actions.h
+++ b/src/tweaks/actions.h
@@ -72,6 +72,11 @@ void action_setLowBatteryAutoSave(void *pt)
     settings.low_battery_autosave = ((ListItem *)pt)->value == 1;
 }
 
+void action_setdisableStandby(void *pt)
+{
+    settings.disable_standby = ((ListItem *)pt)->value == 1;
+}
+
 void action_sethttpstate(void *pt)
 {
     settings.http_state = ((ListItem *)pt)->value == 1;

--- a/src/tweaks/actions.h
+++ b/src/tweaks/actions.h
@@ -72,9 +72,9 @@ void action_setLowBatteryAutoSave(void *pt)
     settings.low_battery_autosave = ((ListItem *)pt)->value == 1;
 }
 
-void action_setdisableStandby(void *pt)
+void action_setPowerSinglePress(void *pt)
 {
-    settings.disable_standby = ((ListItem *)pt)->value == 1;
+    settings.power_single_press = ((ListItem *)pt)->value == 1;
 }
 
 void action_sethttpstate(void *pt)

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -247,7 +247,7 @@ void menu_networks(void *_)
 void menu_system(void *_)
 {
     if (!_menu_system._created) {
-        _menu_system = list_create(4, LIST_SMALL);
+        _menu_system = list_create(5, LIST_SMALL);
         strcpy(_menu_system.title, "System");
         list_addItem(&_menu_system, (ListItem){.label = "Startup...",
                                                .action = menu_systemStartup});
@@ -258,6 +258,11 @@ void menu_system(void *_)
                                 .item_type = TOGGLE,
                                 .value = (int)settings.low_battery_autosave,
                                 .action = action_setLowBatteryAutoSave});
+        list_addItem(&_menu_system,
+                     (ListItem){.label = "Instant turn off (no standby)",
+                                .item_type = TOGGLE,
+                                .value = (int)settings.disable_standby,
+                                .action = action_setdisableStandby});
         list_addItem(
             &_menu_system,
             (ListItem){.label = "Vibration intensity",

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -379,8 +379,8 @@ void menu_buttonAction(void *_)
                                 .item_type = MULTIVALUE,
                                 .value_max = 1,
                                 .value_labels = {"Standby", "Shutdown"},
-                                .value = (int)settings.power_single_press,
-                                .action = action_setPowerSinglePress});
+                                .value = (int)settings.disable_standby,
+                                .action = action_setDisableStandby});
     }
     menu_stack[++menu_level] = &_menu_button_action;
     header_changed = true;

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -247,7 +247,7 @@ void menu_networks(void *_)
 void menu_system(void *_)
 {
     if (!_menu_system._created) {
-        _menu_system = list_create(5, LIST_SMALL);
+        _menu_system = list_create(4, LIST_SMALL);
         strcpy(_menu_system.title, "System");
         list_addItem(&_menu_system, (ListItem){.label = "Startup...",
                                                .action = menu_systemStartup});
@@ -258,11 +258,6 @@ void menu_system(void *_)
                                 .item_type = TOGGLE,
                                 .value = (int)settings.low_battery_autosave,
                                 .action = action_setLowBatteryAutoSave});
-        list_addItem(&_menu_system,
-                     (ListItem){.label = "Instant turn off (no standby)",
-                                .item_type = TOGGLE,
-                                .value = (int)settings.disable_standby,
-                                .action = action_setdisableStandby});
         list_addItem(
             &_menu_system,
             (ListItem){.label = "Vibration intensity",
@@ -347,7 +342,7 @@ void menu_buttonActionInGameMenu(void *_)
 void menu_buttonAction(void *_)
 {
     if (!_menu_button_action._created) {
-        _menu_button_action = list_create(5, LIST_SMALL);
+        _menu_button_action = list_create(6, LIST_SMALL);
         strcpy(_menu_button_action.title, "Button shortcuts");
         list_addItem(&_menu_button_action,
                      (ListItem){.label = "Menu single press vibration",
@@ -379,6 +374,13 @@ void menu_buttonAction(void *_)
                        .value_formatter = formatter_appShortcut,
                        .action_id = 1,
                        .action = action_setAppShortcut});
+        list_addItem(&_menu_button_action,
+                     (ListItem){.label = "Power single press",
+                                .item_type = MULTIVALUE,
+                                .value_max = 1,
+                                .value_labels = {"Standby", "Shutdown"},
+                                .value = (int)settings.power_single_press,
+                                .action = action_setPowerSinglePress});
     }
     menu_stack[++menu_level] = &_menu_button_action;
     header_changed = true;


### PR DESCRIPTION
**What it does:**

Adds a setting "Power single press" with the values "Standby (default)" and "Shutdown" in "Button Shortcuts" 
Setting this to "Shutdown" will make it so the device shuts down at the single press of the power button instead of going to standby.

This disables the standby functionality.

**To test:**

- Go to Apps/Tweaks/Button shortcuts
- Set "Power single press" to "Shutdown"
- Exit out of tweaks to the home menu
- Press and do not hold the power button 
- _The device shuts down_

- Go to Apps/Tweaks/Button shortcuts
- Set "Power single press" to "Standby"
- Exit out of tweaks to the home menu
- Press and do not hold the power button 
- _The device goes into standby_