### PR TITLE
Add a check for the NTP flag at start of main

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -65,6 +65,11 @@ main() {
     mount -o bind /mnt/SDCARD/miyoo/lib/libgamename.so /customer/lib/libgamename.so
 
     start_networking
+	
+	# do an NTP update at startup
+	if flag_enabled NTPState; then
+		ntpdate time.google.com &
+	fi
 
     # Auto launch
     if [ ! -f $sysdir/config/.noAutoStart ]; then

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -38,6 +38,9 @@ main() {
     
     # Make sure MainUI doesn't show charging animation
     touch /tmp/no_charging_ui
+	
+	# Loop breaker for NTP
+	touch /tmp/ntp_run_once
 
     cd $sysdir
     bootScreen "Boot"
@@ -65,12 +68,7 @@ main() {
     mount -o bind /mnt/SDCARD/miyoo/lib/libgamename.so /customer/lib/libgamename.so
 
     start_networking
-	
-	# do an NTP update at startup
-	if flag_enabled NTPState; then
-		ntpdate time.google.com &
-	fi
-
+		
     # Auto launch
     if [ ! -f $sysdir/config/.noAutoStart ]; then
         state_change
@@ -100,7 +98,7 @@ main() {
 	# Set filebrowser branding to onion
 	$sysdir/bin/filebrowser/filebrowser config set --branding.name "Onion" -d $sysdir/bin/filebrowser/filebrowser.db
 	$sysdir/bin/filebrowser/filebrowser config set --branding.files "/mnt/SDCARD/.tmp_update/bin/filebrowser/theme" -d $sysdir/bin/filebrowser/filebrowser.db
-
+	
     # Main runtime loop
     while true; do
         state_change
@@ -570,6 +568,7 @@ runifnecessary() {
         a=`pgrep $1`
     done
 }
+
 
 start_networking() {
     rm $sysdir/config/.HotspotState  # dont start hotspot at boot

--- a/static/build/.tmp_update/script/update_networking.sh
+++ b/static/build/.tmp_update/script/update_networking.sh
@@ -14,6 +14,7 @@ update() {
     check_ntpstate
     check_httpstate
 	check_hotspotstate
+	sync_time &
 }
 
 
@@ -48,7 +49,21 @@ else
 fi
 }
 
+sync_time() {
+    if [ -f "$sysdir/config/.NTPState" ]; then
+        while true; do
+            if [ ! -f "/tmp/ntp_run_once" ]; then
+                break
+            fi
 
+            if ping -q -c 1 google.com > /dev/null 2>&1 ; then
+                ntpdate time.google.com &
+				rm /tmp/ntp_run_once
+            fi
+            sleep 2
+        done
+    fi
+}
 
 # Starts bftpd if the toggle is set to on
 check_ftpstate() { 


### PR DESCRIPTION
### Minor change

Adds a check outside the main loop in runtime.sh which will run at startup to update the system time when NTP (set auto from network) is turned on in tweaks. This doesn't seem to get called at startup when added in start_net or check_net or update_net.sh

Initially said this won't work in update_networking but after looking into it, it's actually failing due to DNS failure which is caused by wifi not being fully up before doing the NTP query, it's intermittent and sometimes would catch wifi just as it came up so have made the following changes.

## Changes:
- Moved away from runtime.sh to keep it tidier.
- Added checks for internet access before trying NTP (pinging a domain to ensure DNS also working) - This is a backgrounded loop.
- Adds a file check to break the loop of sync_time once the inital startup sync is done.

## Test process:
- Enable NTP (set auto from network)
- Turn device off
- Wait 5 minutes, turn device on.
- Wait 5-10 seconds for NTP to do its thing
- Observe time up to date in clock app.