### PR TITLE
FIX: Adds exit condition to NTPwait loop

### DIFF
--- a/static/build/.tmp_update/script/network/update_networking.sh
+++ b/static/build/.tmp_update/script/network/update_networking.sh
@@ -367,7 +367,7 @@ check_hotspotstate() {
         else
 			start_hotspot &
         fi
-    fi
+    fi 
 }
 
 # This is the fallback! 
@@ -379,7 +379,7 @@ sync_time() {
 	if [ -f "$sysdir/config/.ntpState" ] && wifi_enabled; then
 		attempts=0
 		max_attempts=20
-
+		
 		while true; do
 			if [ ! -f "/tmp/ntp_run_once" ]; then
 				break
@@ -393,6 +393,7 @@ sync_time() {
 			attempts=$((attempts+1))
 			if [ $attempts -eq $max_attempts ]; then
 				log "NTPwait: Ran out of time before we could sync, stopping."
+				disable_flag ntpState
 				break
 			fi
 			sleep 1
@@ -401,7 +402,7 @@ sync_time() {
 	fi
 }
 
-check_ntpstate() { # This function checks if the timezone has changed, we call this in the main loop. 
+check_ntpstate() { # This function checks if the timezone has changed, we call this in the main loop.
     if flag_enabled ntpState && wifi_enabled && [ ! -f "$sysdir/config/.hotspotState" ] ; then
         current_tz=$(check_tzid)
 		get_time

--- a/static/build/.tmp_update/script/network/update_networking.sh
+++ b/static/build/.tmp_update/script/network/update_networking.sh
@@ -393,7 +393,6 @@ sync_time() {
 			attempts=$((attempts+1))
 			if [ $attempts -eq $max_attempts ]; then
 				log "NTPwait: Ran out of time before we could sync, stopping."
-				disable_flag ntpState
 				break
 			fi
 			sleep 1


### PR DESCRIPTION
In situations where wifi is lost we can get stuck in the ntpWait loop (can happen randomly as `rm /tmp/ntp_run_once` wouldn't have executed so the file will still exist)

- Added a 20 second timeout.
- Check return value of ntpdate and write log entry if it fails for debug
- Move "rm /tmp/ntp_run_once" out of the loop incase we never make it to the get_time function call, otherwise we get a random long delay exiting tweaks (or completely stuck if the loop won't break)