### PR TITLE
CHORE: Remove leftover "-s" flags and raise debug level

### DIFF
--- a/src/axp/Makefile
+++ b/src/axp/Makefile
@@ -2,7 +2,7 @@ include ../common/config.mk
 
 TARGET = axp
 CFLAGS := $(CFLAGS) -Os -ffunction-sections -fdata-sections -Wall
-LDFLAGS := $(LDFLAGS) -Wl,--gc-sections -s
+LDFLAGS := $(LDFLAGS) -Wl,--gc-sections
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/batmon/Makefile
+++ b/src/batmon/Makefile
@@ -2,7 +2,7 @@ INCLUDE_SHMVAR=1
 include ../common/config.mk
 
 TARGET = batmon
-LDFLAGS := $(LDFLAGS) -s -pthread
+LDFLAGS := $(LDFLAGS) -pthread
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/bootScreen/Makefile
+++ b/src/bootScreen/Makefile
@@ -3,7 +3,7 @@ INCLUDE_SHMVAR=1
 include ../common/config.mk
 
 TARGET = bootScreen
-LDFLAGS := $(LDFLAGS) -s -lSDL -lSDL_image -lSDL_ttf -lSDL_mixer
+LDFLAGS := $(LDFLAGS) -lSDL -lSDL_image -lSDL_ttf -lSDL_mixer
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/chargingState/Makefile
+++ b/src/chargingState/Makefile
@@ -2,7 +2,7 @@ INCLUDE_CJSON=1
 include ../common/config.mk
 
 TARGET = chargingState
-LDFLAGS := $(LDFLAGS) -s -lSDL -lSDL_image -lSDL_ttf
+LDFLAGS := $(LDFLAGS) -lSDL -lSDL_image -lSDL_ttf
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/common/config.mk
+++ b/src/common/config.mk
@@ -34,7 +34,7 @@ OFILES = $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 CFLAGS := -I../../include -I../common -DPLATFORM_$(shell echo $(PLATFORM) | tr a-z A-Z) -DONION_VERSION="\"$(VERSION)\"" -Wall
 
 ifeq ($(DEBUG),1)
-CFLAGS := $(CFLAGS) -DLOG_DEBUG -g
+CFLAGS := $(CFLAGS) -DLOG_DEBUG -g3
 endif
 
 ifeq ($(TEST),1)

--- a/src/easter/Makefile
+++ b/src/easter/Makefile
@@ -1,7 +1,7 @@
 include ../common/config.mk
 
 TARGET = easter
-LDFLAGS := $(LDFLAGS) -s -lSDL -lSDL_image -lSDL_ttf -lSDL_mixer
+LDFLAGS := $(LDFLAGS) -lSDL -lSDL_image -lSDL_ttf -lSDL_mixer
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/jpg2png/Makefile
+++ b/src/jpg2png/Makefile
@@ -10,7 +10,7 @@ CFILES = $(foreach dir, $(SOURCES), $(wildcard $(dir)/*.c))
 OFILES = $(CFILES:.c=.o)
 
 CFLAGS = -Os $(ARCH) -ffunction-sections -fdata-sections -Wall
-LDFLAGS = $(ARCH) -lmi_sys -lmi_gfx -lpng -Wl,-Bstatic -ljpeg -Wl,-Bdynamic -s
+LDFLAGS = $(ARCH) -lmi_sys -lmi_gfx -lpng -Wl,-Bstatic -ljpeg -Wl,-Bdynamic
 
 $(TARGET): $(OFILES)
 	$(CC) $(OFILES) -o $@ $(LDFLAGS)

--- a/src/keymon/Makefile
+++ b/src/keymon/Makefile
@@ -4,7 +4,7 @@ include ../common/config.mk
 
 TARGET = keymon
 CFLAGS := $(CFLAGS) -Os -ffunction-sections -fdata-sections
-LDFLAGS := $(LDFLAGS) -lpthread -lpng -Wl,--gc-sections -s
+LDFLAGS := $(LDFLAGS) -lpthread -lpng -Wl,--gc-sections
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/packageManager/Makefile
+++ b/src/packageManager/Makefile
@@ -2,7 +2,7 @@ INCLUDE_CJSON=1
 include ../common/config.mk
 
 TARGET = packageManager
-LDFLAGS := $(LDFLAGS) -s -lSDL -lSDL_image -lSDL_ttf
+LDFLAGS := $(LDFLAGS) -lSDL -lSDL_image -lSDL_ttf
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/playActivity/Makefile
+++ b/src/playActivity/Makefile
@@ -1,7 +1,7 @@
 include ../common/config.mk
 
 TARGET = playActivity
-LDFLAGS := $(LDFLAGS) -s -lsqlite3
+LDFLAGS := $(LDFLAGS) -lsqlite3
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/playActivityUI/Makefile
+++ b/src/playActivityUI/Makefile
@@ -1,7 +1,7 @@
 include ../common/config.mk
 
 TARGET = playActivityUI
-LDFLAGS := $(LDFLAGS) -s -lSDL -lSDL_image -lSDL_ttf -lsqlite3
+LDFLAGS := $(LDFLAGS) -lSDL -lSDL_image -lSDL_ttf -lsqlite3
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/pngScale/Makefile
+++ b/src/pngScale/Makefile
@@ -2,7 +2,7 @@ INCLUDE_SHMVAR=1
 include ../common/config.mk
 
 TARGET = pngScale
-LDFLAGS := $(LDFLAGS) -lSDL  -lmi_sys -lmi_gfx -lpng -s
+LDFLAGS := $(LDFLAGS) -lSDL  -lmi_sys -lmi_gfx -lpng
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/randomGamePicker/Makefile
+++ b/src/randomGamePicker/Makefile
@@ -2,7 +2,7 @@ INCLUDE_CJSON=1
 include ../common/config.mk
 
 TARGET = randomGamePicker
-LDFLAGS := $(LDFLAGS) -s -lsqlite3
+LDFLAGS := $(LDFLAGS) -lsqlite3
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/themeSwitcher/Makefile
+++ b/src/themeSwitcher/Makefile
@@ -2,7 +2,7 @@ INCLUDE_CJSON=1
 include ../common/config.mk
 
 TARGET = themeSwitcher
-LDFLAGS := $(LDFLAGS) -s -lSDL -lSDL_image -lSDL_ttf
+LDFLAGS := $(LDFLAGS) -lSDL -lSDL_image -lSDL_ttf
 
 include ../common/commands.mk
 include ../common/recipes.mk


### PR DESCRIPTION
Some binaries still had "-s" in their Makefiles which prevented them from being built with debug symbols. For non-debug builds the symbols are stripped in a seperate step, so this is unnecessary.

Also raised debug level to -g3 to allow for better debugging.