### PR TITLE
CHORE:Replace zip with 7z in build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,22 +190,22 @@ dist: build
 	@$(ECHO) $(PRINT_RECIPE)
 # Package configs
 	@cp -R $(TEMP_DIR)/configs/Saves/CurrentProfile/ $(TEMP_DIR)/configs/Saves/GuestProfile
-	@cd $(TEMP_DIR)/configs && zip -rq $(BUILD_DIR)/.tmp_update/config/configs.pak .
+	@cd $(TEMP_DIR)/configs && 7z a -r -mtm=off $(BUILD_DIR)/.tmp_update/config/configs.pak . -bsp0 -bso0
 	@rm -rf $(TEMP_DIR)/configs
 	@rmdir $(TEMP_DIR)
 # Package RetroArch separately
-	@cd $(BUILD_DIR) && zip -rq retroarch.pak RetroArch
+	@cd $(BUILD_DIR) && 7z a -r -mtm=off retroarch.pak RetroArch -bsp0 -bso0
 	@mkdir -p $(DIST_DIR)/RetroArch
 	@mv $(BUILD_DIR)/retroarch.pak $(DIST_DIR)/RetroArch/
 	@echo $(RA_SUBVERSION) > $(DIST_DIR)/RetroArch/ra_package_version.txt
 # Package Onion core
-	@cd $(BUILD_DIR) && zip -rq $(DIST_DIR)/miyoo/app/.tmp_update/onion.pak . -x RetroArch RetroArch/\*
+	@cd $(BUILD_DIR) && 7z a -r -mtm=off $(DIST_DIR)/miyoo/app/.tmp_update/onion.pak . -xr!RetroArch -bsp0 -bso0
 	@$(ECHO) "\n-> [DIST READY!]"
 
 release: dist
 	@$(ECHO) $(PRINT_RECIPE)
 	@rm -f $(RELEASE_DIR)/$(RELEASE_NAME).zip
-	@cd $(DIST_DIR) && zip -rq $(RELEASE_DIR)/$(RELEASE_NAME).zip .
+	@cd $(DIST_DIR) && 7z a -r -mtc=off $(RELEASE_DIR)/$(RELEASE_NAME).zip . -bsp0 -bso0
 	@$(ECHO) "\n-> [RELEASE READY!]"
 
 clean:

--- a/static/dist/miyoo/app/.tmp_update/install.sh
+++ b/static/dist/miyoo/app/.tmp_update/install.sh
@@ -631,10 +631,12 @@ unzip_progress() {
     while [ -n "$a" ]; do
         last_line=$(tail -n 1 /tmp/.extraction_output)
         value=$(echo "$last_line" | sed 's/.* \([0-9]\+\)%.*/\1/')
-        if [ "$value" -eq "$value" ] && [ $value -eq 0 ] 2>/dev/null; then # check if the value is numeric. If it is 0, show a different message
-            echo "Preparing folders..." > /tmp/.update_msg
-        elif [ "$value" -eq "$value" ] && [ $value -gt 0 ] 2>/dev/null; then    
-            echo "$msg $value%" > /tmp/.update_msg
+        if [ "$value" -eq "$value" ] 2>/dev/null; then                  # check if the value is numeric
+            if [ $value -eq 0 ]; then
+                echo "Preparing folders..." > /tmp/.update_msg          # It gets stuck a bit at 0%, so don't show percentage yet
+            else
+                echo "$msg $value%" > /tmp/.update_msg                  # Now we can show completion percentage
+            fi
         fi
         > /tmp/.extraction_output  # to avoid to parse a too big file
         sleep 0.5

--- a/static/dist/miyoo/app/.tmp_update/install.sh
+++ b/static/dist/miyoo/app/.tmp_update/install.sh
@@ -588,73 +588,74 @@ unzip_progress() {
 
     echo "   - Extract '$zipfile' into $dest"
 
+    verify_file
 
-verify_file
+    echo "Starting..." > /tmp/.update_msg
+    sleep 3
 
-echo "Starting..." > /tmp/.update_msg
-sleep 3
-
-if [ -f "/mnt/SDCARD/.tmp_update/onion.pak" ]; then
-	echo "onion.pak exists"
-	sleep 1
-else
-	echo "onion.pak is missing, extraction will fail"
-fi
-
-verify_file
-
-sleep 1
-
-# Run the 7z extraction command in the background and redirect output to /tmp/.extraction_output
-(7z x -aoa -o"$dest" "$zipfile" -bsp1 -bb > /tmp/.extraction_output ; echo $? > "/tmp/extraction_status" ) &
-
-sleep 1 
-
-if pgrep 7z > /dev/null; then
-    echo "7Z is running"
-	sleep 1
-else
-    echo "7Z is NOT running and should be"
-	sleep 1
-fi
-
-if [ -f "/mnt/SDCARD/.tmp_update/onion.pak" ]; then
-	echo "onion.pak still exists"
-	sleep 1
-else
-	echo "onion.pak is still missing, extraction has probably failed"
-	sleep 1
-	echo "the build will say it's complete but isn't"
-fi
-
-# Continuously update /tmp/.update_msg every 500 milliseconds until the command line finishes
-a=$(pgrep 7z)
-while [ -n "$a" ]; do
-    last_line=$(tail -n 1 /tmp/.extraction_output)
-    value=$(echo "$last_line" | sed 's/.* \([0-9]\+\)%.*/\1/')
-    if [ "$value" -eq "$value" ] 2>/dev/null; then    # check if the value is numeric
-        echo "$msg $value%" > /tmp/.update_msg
+    if [ -f "/mnt/SDCARD/.tmp_update/onion.pak" ]; then
+        echo "onion.pak exists"
+        sleep 1
+    else
+        echo "onion.pak is missing, extraction will fail"
     fi
-    > /tmp/.extraction_output  # to avoid to parse a too big file
-    sleep 0.5
+
+    verify_file
+
+    sleep 1
+
+    # Run the 7z extraction command in the background and redirect output to /tmp/.extraction_output
+    (7z x -aoa -o"$dest" "$zipfile" -bsp1 -bb > /tmp/.extraction_output ; echo $? > "/tmp/extraction_status" ) &
+
+    sleep 1 
+
+    if pgrep 7z > /dev/null; then
+        echo "7Z is running"
+        sleep 1
+    else
+        echo "7Z is NOT running and should be"
+        sleep 1
+    fi
+
+    if [ -f "/mnt/SDCARD/.tmp_update/onion.pak" ]; then
+        echo "onion.pak still exists"
+        sleep 1
+    else
+        echo "onion.pak is still missing, extraction has probably failed"
+        sleep 1
+        echo "the build will say it's complete but isn't"
+    fi
+
+    # Continuously update /tmp/.update_msg every 500 milliseconds until the command line finishes
     a=$(pgrep 7z)
-done
+    while [ -n "$a" ]; do
+        last_line=$(tail -n 1 /tmp/.extraction_output)
+        value=$(echo "$last_line" | sed 's/.* \([0-9]\+\)%.*/\1/')
+        if [ "$value" -eq "$value" ] && [ $value -eq 0 ] 2>/dev/null; then # check if the value is numeric. If it is 0, show a different message
+            echo "Preparing folders..." > /tmp/.update_msg
+        elif [ "$value" -eq "$value" ] && [ $value -gt 0 ] 2>/dev/null; then    
+            echo "$msg $value%" > /tmp/.update_msg
+        fi
+        > /tmp/.extraction_output  # to avoid to parse a too big file
+        sleep 0.5
+        a=$(pgrep 7z)
+    done
 
-# Check the exit status of the extraction command
-extraction_status=$(cat "/tmp/extraction_status")
-if [ "$extraction_status" -ne 0 ]; then
-    touch $sysdir/.installFailed
-    echo ":: Installation failed!"
-    sync
-    reboot
-    sleep 10
-    exit 0
-else
-    echo "$msg 100%" >> /tmp/.update_msg
-fi
+    # Check the exit status of the extraction command
+    extraction_status=$(cat "/tmp/extraction_status")
+    if [ "$extraction_status" -ne 0 ]; then
+        touch $sysdir/.installFailed
+        echo ":: Installation failed!"
+        sync
+        reboot
+        sleep 10
+        exit 0
+    else
+        echo "$msg 100%" >> /tmp/.update_msg
+    fi
 
-rm /tmp/extraction_status
-rm /tmp/.extraction_output
+    rm /tmp/extraction_status
+    rm /tmp/.extraction_output
 }
 
 free_mma() {


### PR DESCRIPTION
As discussed, replace zip with 7z in build process.
Change installation message to "Preparing folders"... while stuck at 0%

Allows for reproducible .pak files.
Also reduces release file size by ~20% (release.zip ~500MB to 400MB), install time increases by about 10 seconds.

Tested on SanDisk ultra 32GB from press of power button until Quick Guide shows up:
dev-41caa40: 2 minutes 59 seconds
with this PR:   3 minutes 10 seconds

I've tested fresh install and update on MM+