### PR TITLE
FIX: Replace unzip with 7z for configs.pak and Tweaks

### DIFF
--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -447,7 +447,7 @@ void menu_resetSettings(void *_)
         strcpy(_menu_reset_settings.title, "Reset settings");
         list_addItem(&_menu_reset_settings,
                      (ListItem){
-                         .label = "Reset tweaks",
+                         .label = "Reset system tweaks",
                          .action = action_resetTweaks});
         list_addItem(&_menu_reset_settings,
                      (ListItem){

--- a/src/tweaks/reset.h
+++ b/src/tweaks/reset.h
@@ -79,8 +79,8 @@ void action_resetTweaks(void *pt)
     rename(RESET_CONFIGS_PAK, "/mnt/SDCARD/.tmp_update/temp");
     system("rm -rf /mnt/SDCARD/.tmp_update/config && mkdir -p "
            "/mnt/SDCARD/.tmp_update/config");
-    system("unzip /mnt/SDCARD/.tmp_update/temp \".tmp_update/config/*\" -d "
-           "/mnt/SDCARD/");
+    system("7z x /mnt/SDCARD/.tmp_update/temp -o/mnt/SDCARD/ "
+            "-ir!.tmp_update/config/*");
     rename("/mnt/SDCARD/.tmp_update/temp", RESET_CONFIGS_PAK);
     reset_menus = true;
     settings_load();
@@ -103,15 +103,14 @@ void action_resetThemeOverrides(void *pt)
 void action_resetMainUI(void *pt)
 {
     const char title_str[] = "Reset MainUI settings";
+    const char cmd_str[80];
     if (!_disable_confirm &&
         !_confirmReset(title_str,
                        "Are you sure you want to\nreset MainUI settings?"))
         return;
     system("rm -f /appconfigs/system.json");
-    system("unzip -o " RESET_CONFIGS_PAK
-           " \".tmp_update/config/system.json\" -d /mnt/SDCARD/");
-    system("cp /mnt/SDCARD/.tmp_update/config/system.json "
-           "/appconfigs/system.json");
+    sprintf(cmd_str, "cp /mnt/SDCARD/.tmp_update/res/miyoo%d_system.json /appconfigs/system.json", DEVICE_ID);
+    system(cmd_str);
     reset_menus = true;
     settings_load();
     if (!_disable_confirm)
@@ -126,7 +125,8 @@ void action_resetRAMain(void *pt)
             title_str,
             "Are you sure you want to reset\nRetroArch main configuration?"))
         return;
-    system("unzip -o " RESET_CONFIGS_PAK " \"RetroArch/*\" -d /mnt/SDCARD/");
+    system("7z x -aoa " RESET_CONFIGS_PAK " -o/mnt/SDCARD/ "
+           "-ir!RetroArch/*");
     reset_menus = true;
     if (!_disable_confirm)
         _notifyResetDone(title_str);
@@ -141,8 +141,8 @@ void action_resetRACores(void *pt)
             "Are you sure you want to reset\nall RetroArch core overrides?"))
         return;
     system("rm -rf /mnt/SDCARD/Saves/CurrentProfile/config/*");
-    system("unzip -o " RESET_CONFIGS_PAK
-           " \"Saves/CurrentProfile/config/*\" -d /mnt/SDCARD/");
+    system("7z x " RESET_CONFIGS_PAK " -o/mnt/SDCARD/ "
+           " -ir!Saves/CurrentProfile/config/*");
     reset_menus = true;
     if (!_disable_confirm)
         _notifyResetDone(title_str);
@@ -156,8 +156,8 @@ void action_resetAdvanceMENU(void *pt)
             title_str,
             "Are you sure you want to\nreset AdvanceMENU/MAME/MESS?"))
         return;
-    system("unzip -o " RESET_CONFIGS_PAK
-           " \"BIOS/.advance/*\" -d /mnt/SDCARD/");
+    system("7z x -aoa " RESET_CONFIGS_PAK " -o/mnt/SDCARD/ "
+        "-ir!BIOS/.advance/*");
     reset_menus = true;
     if (!_disable_confirm)
         _notifyResetDone(title_str);

--- a/src/tweaks/reset.h
+++ b/src/tweaks/reset.h
@@ -103,7 +103,7 @@ void action_resetThemeOverrides(void *pt)
 void action_resetMainUI(void *pt)
 {
     const char title_str[] = "Reset MainUI settings";
-    const char cmd_str[80];
+    char cmd_str[80];
     if (!_disable_confirm &&
         !_confirmReset(title_str,
                        "Are you sure you want to\nreset MainUI settings?"))

--- a/src/tweaks/reset.h
+++ b/src/tweaks/reset.h
@@ -79,10 +79,8 @@ void action_resetTweaks(void *pt)
     if (!_disable_confirm && !_confirmReset(title_str, "Are you sure you want to\nreset system tweaks?"))
         return;
     rename(RESET_CONFIGS_PAK, "/mnt/SDCARD/.tmp_update/temp");
-    system("rm -rf /mnt/SDCARD/.tmp_update/config && mkdir -p "
-           "/mnt/SDCARD/.tmp_update/config");
-    system("7z x /mnt/SDCARD/.tmp_update/temp -o/mnt/SDCARD/ "
-           "-ir!.tmp_update/config/*");
+    system("rm -rf /mnt/SDCARD/.tmp_update/config && mkdir -p /mnt/SDCARD/.tmp_update/config");
+    system("7z x /mnt/SDCARD/.tmp_update/temp -o/mnt/SDCARD/ -ir!.tmp_update/config/*");
     rename("/mnt/SDCARD/.tmp_update/temp", RESET_CONFIGS_PAK);
     reset_menus = true;
     settings_load();
@@ -103,12 +101,13 @@ void action_resetThemeOverrides(void *pt)
 void action_resetMainUI(void *pt)
 {
     const char title_str[] = "Reset MainUI settings";
-    char cmd_str[80];
 
     if (!_disable_confirm && !_confirmReset(title_str, "Are you sure you want to\nreset MainUI settings?"))
         return;
 
     system("rm -f /appconfigs/system.json");
+
+    char cmd_str[80];
     sprintf(cmd_str, "cp /mnt/SDCARD/.tmp_update/res/miyoo%d_system.json /appconfigs/system.json", DEVICE_ID);
     system(cmd_str);
 

--- a/src/tweaks/reset.h
+++ b/src/tweaks/reset.h
@@ -80,7 +80,7 @@ void action_resetTweaks(void *pt)
     system("rm -rf /mnt/SDCARD/.tmp_update/config && mkdir -p "
            "/mnt/SDCARD/.tmp_update/config");
     system("7z x /mnt/SDCARD/.tmp_update/temp -o/mnt/SDCARD/ "
-            "-ir!.tmp_update/config/*");
+           "-ir!.tmp_update/config/*");
     rename("/mnt/SDCARD/.tmp_update/temp", RESET_CONFIGS_PAK);
     reset_menus = true;
     settings_load();
@@ -157,7 +157,7 @@ void action_resetAdvanceMENU(void *pt)
             "Are you sure you want to\nreset AdvanceMENU/MAME/MESS?"))
         return;
     system("7z x -aoa " RESET_CONFIGS_PAK " -o/mnt/SDCARD/ "
-        "-ir!BIOS/.advance/*");
+           "-ir!BIOS/.advance/*");
     reset_menus = true;
     if (!_disable_confirm)
         _notifyResetDone(title_str);

--- a/static/build/.tmp_update/res/wpa_supplicant.reset
+++ b/static/build/.tmp_update/res/wpa_supplicant.reset
@@ -1,0 +1,3 @@
+ctrl_interface=/var/run/wpa_supplicant
+update_config=1
+

--- a/static/dist/miyoo/app/.tmp_update/install.sh
+++ b/static/dist/miyoo/app/.tmp_update/install.sh
@@ -452,10 +452,10 @@ install_configs() {
     if [ $reset_configs -eq 1 ]; then
         # Overwrite all default configs
         rm -rf /mnt/SDCARD/Saves/CurrentProfile/config/*
-        unzip -oq $zipfile
+        7z x -aoa $zipfile # aoa = overwrite existing files
     else
         # Extract config files without overwriting any existing files
-        unzip -nq $zipfile
+        7z x -aos $zipfile # aos = skip existing files
     fi
 
     # Set X and Y button keymaps if empty


### PR DESCRIPTION
#976 introduced a bug, it failed to extract the config files on installation, because they are packed in 7z (LZMA) format and unpacked with unzip.
Fixed by replacing unzip with 7z

"Reset MainUI settings" was not working because, it tried to extract system.json from config.pak, which isn't in there anymore since at least 4.1.4. Copy it from /mnt/SDCARD/.tmp_update/res/ instead. Choose the right one depending on DEVICE_ID.

Replace unzip with 7z in all Tweaks/Reset actions that require unpacking. This also did not work anymore because #976 changed the format of config.pak from zip to 7z (LZMA).

Testing procedure:

- [x] Change at least one setting in Tweaks, for example "Vibration intensity".
- [x] In Tweaks/Advanced/Reset settings run "Reset tweaks". 
- [x] Observe all tweaks settings (and no others) are reset.
- [x] Change at least one MainUI setting, for example "Sleep timer".
- [x] In Tweaks/Advanced/Reset settings run "Reset MainUI settings".
- [x] Observe all MainUI settings (and no others) are reset.
- [x] Change at least one RetroArch setting, for example "Language". Make sure to save the configuration.
- [x] In Tweaks/Advanced/Reset settings run "Reset RetroArch main configuration"
- [x] Observe all RetroArch main settings (and no others) are reset.
- [x] Start RetroArch, select "Load Content", "Contentless Cores", "2048"
- [x] Enable a Core Override setting, for example select an "Overlay Preset"
- [x] Save Core Overrides and quit RetroArch
- [x] In Tweaks/Advanced/Reset settings run "Reset all RetroArch core overrides"
- [x] Observe the previously changed core override is now reset.
- [x] Seperately tested "Reset MainUI settings" on the 283