### PR TITLE
REFACTOR: Changes to Easy Netplay & Pokemon trading GLO scripts

### DIFF
--- a/static/build/.tmp_update/script/easynetplay/netplay_client.sh
+++ b/static/build/.tmp_update/script/easynetplay/netplay_client.sh
@@ -169,7 +169,7 @@ sync_file() {
 
 	if [ -z "$file_path" ]; then
         build_infoPanel_and_log "Something went wrong" "We didn't receive a file path for the rom \n Cannot continue."
-        sleep 1
+        sleep 2
         cleanup
 	fi
 
@@ -188,13 +188,14 @@ sync_file() {
 
 			if [ "$file_checksum" -ne "$file_chksum_actual" ]; then
 				build_infoPanel_and_log "Checksum Mismatch" "The Rom exists but the checksum doesn't match \n Cannot continue."
+                sleep 2
                 cleanup
 			else
 				build_infoPanel_and_log "Rom Check Complete!" "Rom exists and checksums match!"
 			fi
 		else
 			build_infoPanel_and_log "Rom Missing" "The Rom doesn't exist on the client \n Cannot continue."
-            sleep 1
+            sleep 2
             cleanup
 		fi
 	else
@@ -217,6 +218,7 @@ sync_file() {
 
 				if [ ! -e "$file_path" ]; then
 					build_infoPanel_and_log "Sync Failed" "Failed to download the $file_type file."
+                    sleep 2
 					cleanup
 				else
 					build_infoPanel_and_log "Syncing" "$file_type synced."
@@ -231,6 +233,7 @@ sync_file() {
 
 			if [ ! -e "$file_path" ]; then
 				build_infoPanel_and_log "Sync Failed" "Failed to download the $file_type file."
+                sleep 2
 				cleanup
 			else
 				build_infoPanel_and_log "Syncing" "$file_type synced."

--- a/static/build/.tmp_update/script/easynetplay/pokemon_client.sh
+++ b/static/build/.tmp_update/script/easynetplay/pokemon_client.sh
@@ -1,6 +1,5 @@
 # GLO Pokemon trade
 # Used within GLO as an addon script.
-#
 
 # Env setup
 sysdir=/mnt/SDCARD/.tmp_update
@@ -19,14 +18,14 @@ hostip="192.168.100.100" # This should be the default unless the user has change
 
 # We'll need wifi up for this. Lets try and start it..
 
+build_infoPanel_and_log "WIFI" "Wifi up"
+
 check_wifi() {
 	if ifconfig wlan0 &>/dev/null; then
-		log "GLO::Pokemon_Netplay: Wi-Fi is up already"
-		build_infoPanel "WIFI" "Wifi up"
+		build_infoPanel_and_log "WIFI" "Wifi up"
 		save_wifi_state
 	else
-		log "GLO::Pokemon_Netplay: Wi-Fi disabled, trying to enable before connecting.."
-		build_infoPanel "WIFI" "Wifi disabled, starting..." 
+		build_infoPanel_and_log "WIFI" "Wifi disabled, starting..." 
 		
 		/customer/app/axp_test wifion
 		sleep 2
@@ -35,11 +34,9 @@ check_wifi() {
 		$miyoodir/app/wpa_supplicant -B -D nl80211 -iwlan0 -c /appconfigs/wpa_supplicant.conf
 		
 		if is_running wpa_supplicant && ifconfig wlan0 > /dev/null 2>&1; then
-			log "GLO::Pokemon_Netplay: WiFi started"
-			build_infoPanel "WIFI" "Wifi started."
+			build_infoPanel_and_log "WIFI" "Wifi started."
 		else
-			log "GLO::Pokemon_Netplay: WiFi started"
-			build_infoPanel "WIFI" "Unable to start WiFi\n unable to continue."
+			build_infoPanel_and_log "WIFI" "Unable to start WiFi\n unable to continue."
 			sleep 1
 			cleanup
 		fi
@@ -51,11 +48,11 @@ check_wifi() {
 
 # Create a new network id, set it up and enable it, start udhcpc against it.
 connect_to_host() {
-	build_infoPanel "Connecting..." "Trying to join the hotspot..."
+	build_infoPanel_and_log "Connecting..." "Trying to join the hotspot..."
 
 	export new_id=$($WPACLI -i wlan0 add_network)
 	if [ -z "$new_id" ]; then
-		build_infoPanel "Failed"  "Failed to create network\n unable to continue." 
+		build_infoPanel_and_log "Failed"  "Failed to create network\n unable to continue." 
 		return 1
 	fi
 	
@@ -74,8 +71,7 @@ connect_to_host() {
 	)
 	
 	if [ $? -ne 0 ]; then
-		build_infoPanel "Failed"  "Failed to configure the network\n unable to continue." 
-        log "GLO::Pokemon_Netplay: Network configuration failed - unable to continue"
+		build_infoPanel_and_log "Failed"  "Failed to configure the network\n unable to continue." 
 		sleep 1
 		cleanup
 	fi
@@ -93,7 +89,7 @@ connect_to_host() {
 
 # We'd better wait for an ip address to be assigned before going any further.
 wait_for_connectivity() {
-    build_infoPanel "Connecting..."  "Trying to reach $hostip..."
+    build_infoPanel_and_log "Connecting..."  "Trying to reach $hostip..."
     counter=0
 
     while ! ping -c 1 -W 1 $hostip > /dev/null 2>&1; do
@@ -101,15 +97,13 @@ wait_for_connectivity() {
         counter=$((counter+1))
 
         if [ $counter -ge 40 ]; then
-            build_infoPanel "Failed to connect!"  "Could not reach $IP in 20 seconds."
-            log "GLO::Pokemon_Netplay: Failed to reach $IP within 20 seconds."
+            build_infoPanel_and_log "Failed to connect!"  "Could not reach $IP in 20 seconds."
             sleep 1 
             cleanup
         fi
     done
 
-    build_infoPanel "Joined hotspot!"  "Successfully reached the Hotspot! \n IP: $hostip" 
-    log "GLO::Pokemon_Netplay: Successfully reached: $hostip"
+    build_infoPanel_and_log "Joined hotspot!"  "Successfully reached the Hotspot! \n IP: $hostip" 
     sleep 1
 }
 
@@ -120,21 +114,18 @@ download_cookie() {
     curl -o "$output_path" ftp://$hostip/mnt/SDCARD/RetroArch/retroarch.cookie
 
     if [ $? -ne 0 ]; then
-        log "GLO::Pokemon_Netplay: Failed to download cookie file."
-		build_infoPanel "Failed"  "Can't download the cookie, can't continue" 
+		build_infoPanel_and_log "Failed"  "Can't download the cookie, can't continue" 
 		sleep 1
         cleanup
     fi
 
     if [ ! -f $output_path ]; then
-        log "GLO::Pokemon_Netplay: We didn't get a cookie"
-		build_infoPanel "No cookie found"  "Cookie has been eaten, can't continue" 
+		build_infoPanel_and_log "No cookie found"  "Cookie has been eaten, can't continue" 
 		sleep 1
         cleanup
     fi
 	
-	build_infoPanel "Success!"  "Got the cookie" 
-    log "GLO::Pokemon_Netplay: Cookie file downloaded successfully."
+	build_infoPanel_and_log "Success!"  "Got the cookie" 
 }
 
 # Read the cookie and store the paths and checksums into a var.
@@ -165,7 +156,6 @@ read_cookie() {
     log "GLO::Pokemon_Netplay: $core $rom"
 	
 	#url encode or curl complains
-	export rom_url=$(echo "$rom" | sed 's/ /%20/g')
 	export core_url=$(echo "$core" | sed 's/ /%20/g')
 
 	log "GLO::Pokemon_Netplay: Cookie file read"
@@ -186,8 +176,7 @@ get_cookie_info() {
 # Push our saves over to the host - The save will be found based on the rom we've started GLO on and it will look in the $save_dir path for it (see line13) - Backs up first
 send_saves() {
     missing=""
-    build_infoPanel "Syncing saves" "Syncing our save files with the host"
-    log "GLO::Pokemon_Netplay: Syncing saves with the host"
+    build_infoPanel_and_log "Syncing saves" "Syncing our save files with the host"
     save_file_filename_full=$(basename "$local_rom")
     save_file_filename="${save_file_filename_full%.*}"
     save_file_matched=$(find "$save_dir" -name "$save_file_filename.srm" -not -name "*.rtc" -not -path "*/.netplay/*")
@@ -204,8 +193,7 @@ send_saves() {
     curl -T "$save_file_matched" "ftp://$hostip/tmp/$encoded_save_file"
 
     if [ "$missing" = "1" ]; then
-        build_infoPanel "Save not found" "You don't have a save for this game, \n or we failed to find it. Cannot continue \n Notified host."
-        log "GLO::Pokemon_Netplay: The local client is missing the save file for this game, please check the TGB Dual directory."
+        build_infoPanel_and_log "Save not found" "You don't have a save for this game, \n or we failed to find it. Cannot continue \n Notified host."
         sleep 2
         cleanup
     fi
@@ -221,12 +209,14 @@ backup_save() {
 
 # Wait for the host to tell us it's ready, this happens just before it starts its RA session and we look in /tmp for a file indicator (file removed in host script cleanup)
 wait_for_host() {
+    local counter=0
+
+    build_infoPanel_and_log "Ready" "Waiting for host to ready up"
     while true; do
         sync
         for file in /tmp/host_ready; do
             if [ -f "$file" ]; then
-                build_infoPanel "Message from host" "Setup complete"
-                log "GLO::Pokemon_Netplay: Received notification host is ready"
+                build_infoPanel_and_log "Message from host" "Setup complete"
                 break 2
             fi
         done
@@ -235,12 +225,14 @@ wait_for_host() {
         counter=$((counter + 1))
 
         if [ $counter -ge 25 ]; then
-            build_infoPanel "Error" "The host didn't ready up, cannot continue..."
+            build_infoPanel_and_log "Error" "The host didn't ready up, cannot continue..."
             sleep 1
             cleanup
+            break
         fi
     done
 }
+
 
 # Set the screen and audio settings in TGB dual as these aren't default in Onion
 change_tgb_dual_opt() {
@@ -276,7 +268,7 @@ change_tgb_dual_opt() {
 # We'll start Retroarch in host mode with -H with the core and rom paths loaded in.
 start_retroarch() {
     sync
-	build_infoPanel "RetroArch" "Starting RetroArch..."
+	build_infoPanel_and_log "RetroArch" "Starting RetroArch..."
     log "GLO::Pokemon_Netplay: Starting RetroArch loaded with $rom and $local_rom"
 	cd /mnt/SDCARD/RetroArch
     HOME=/mnt/SDCARD/RetroArch ./retroarch -C $hostip -v -L .retroarch/cores/tgbdual_libretro.so --subsystem "gb_link_2p" "$rom" "$local_rom"
@@ -284,15 +276,15 @@ start_retroarch() {
 
 # Go into a waiting state for the host to return the save
 wait_for_save_return() {
-    build_infoPanel "Syncing" "Waiting for host to be ready for save sync"
-    touch /tmp/ready_to_receive
-    curl -T "/tmp/ready_to_receive" "ftp://$hostip/tmp/ready_to_receive" > /dev/null 2>&1
+    build_infoPanel_and_log "Syncing" "Waiting for host to be ready for save sync"
+    notify_peer "ready_to_receive"
+    
+    sync
     
     while true; do
-        sync
         for file in /tmp/ready_to_send; do
             if [ -f "$file" ]; then
-                build_infoPanel "Message from Host" "Host is ready to send save"
+                build_infoPanel_and_log "Message from Host" "Host is ready to send save"
                 log "GLO::Pokemon_Netplay: Received notification \n Host is ready to send the save"
                 break 2
             fi
@@ -301,8 +293,8 @@ wait_for_save_return() {
         sleep 1
         counter=$((counter + 1))
 
-        if [ $counter -ge 25 ]; then
-            build_infoPanel "Error" "The Host didn't ready up, cannot continue..."
+        if [ $counter -ge 20 ]; then
+            build_infoPanel_and_log "Error" "The Host didn't ready up, cannot continue..."
             log "GLO::Pokemon_Netplay: We ran out of time waiting for the host to ready up, possibly due to host->client connecitivity"
             sleep 1
             cleanup
@@ -312,23 +304,22 @@ wait_for_save_return() {
     sleep 3
     sync
     
+    log "cp -f \"${save_file_matched}_rcvd\" \"$save_file_matched\""
     cp -f "${save_file_matched}_rcvd" "$save_file_matched"
     cp_exit_status=$?
-
+    
     if [ $cp_exit_status -eq 0 ]; then
-        log "GLO::Pokemon_Netplay: Save successfully merged"
-        build_infoPanel "Syncing save" "Save merged successfully"
+        build_infoPanel_and_log "Syncing save" "Save merged successfully"
         sleep 1
     else
-        log "GLO::Pokemon_Netplay: Failed to merge save, cp returned: $cp_exit_status"
-        build_infoPanel "Syncing save" "Failed to merge save"
+        build_infoPanel_and_log "Syncing save" "Failed to merge save \n Error code: $cp_exit_status"
         sleep 1
     fi
 }
 
 # If you don't call this you don't retransfer the saves - Users cannot under any circumstances miss this function.
 cleanup() {
-	build_infoPanel "Cleanup" "Cleaning up after Pokemon session\n Do not power off!"
+	build_infoPanel_and_log "Cleanup" "Cleaning up after Pokemon session\n Do not power off!"
 
 	pkill -9 pressMenu2Kill
 
@@ -346,7 +337,7 @@ cleanup() {
 	)
 	
 	if [ $? -ne 0 ]; then
-		log "GLO::Pokemon_Netplay: Failed to configure the network"
+        build_infoPanel_and_log "Cleanup" "Failed to configure the network"
 	fi
     
     udhcpc_control
@@ -364,6 +355,7 @@ cleanup() {
     rm "$tgb_dual_opts.bak"
     rm "$save_dir/MISSING.srm"
     rm "/tmp/MISSING.srm"
+    rm "/tmp/stop_now"
 		
 	log "GLO::Pokemon_Netplay: Cleanup done"
 	exit
@@ -378,55 +370,105 @@ url_encode() {
     echo "$1" | sed 's/ /%20/g'
 }
 
+# Notify other MMP
+notify_peer() {
+    local notify_file="/tmp/$1"
+    touch "$notify_file"
+    sync
+    curl -T "$notify_file" "ftp://$hostip/$notify_file" > /dev/null 2>&1
+    
+    if [ $? -eq 0 ]; then
+        log "GLO::Pokemon_Netplay: Successfully transferred $notify_file to ftp://$hostip/$notify_file"
+    else
+        log "GLO::Pokemon_Netplay: Failed to transfer $notify_file to ftp://$hostip/$notify_file"
+    fi
+}
+
 # Function to sync files
 sync_file() {
-    file_type="$1"
-    file_path="$2"
-    file_checksum="$3"
-    file_url="$4"
-    MAX_FILE_SIZE_BYTES=26214400
-	
+	file_type="$1"
+	file_path="$2"
+	file_checksum="$3"
+	file_url="$4"
+	MAX_FILE_SIZE_BYTES=26214400
 
-    if [ -e "$file_path" ]; then
-        log "GLO::Pokemon_Netplay: $file_path exists."
-        
-        local file_size=$(stat -c%s "$file_path")
-        local file_chksum_actual
+	if [ -z "$file_path" ]; then
+        build_infoPanel_and_log "Something went wrong" "We didn't receive a file path for the rom \n Cannot continue."
+        sleep 2
+        cleanup
+	fi
 
-        if [ "$file_size" -gt "$MAX_FILE_SIZE_BYTES" ]; then
-            file_chksum_actual=$file_size
-        else
-            file_chksum_actual=$(cksum "$file_path" | awk '{ print $1 }')
-        fi
+	if [ "$file_type" == "Rom" ]; then
+		if [ -e "$file_path" ]; then
+			log "GLO::Pokemon_Netplay: $file_path exists."
 
-        if [ "$file_checksum" -ne "$file_chksum_actual" ]; then
-            log "GLO::Pokemon_Netplay: Checksum doesn't match for $file_path. Renaming the existing file and syncing $file_type again."
-            build_infoPanel "Syncing"  "$file_type checksums don't match, syncing" 
-            sleep 0.5
-            do_sync_file "$file_type" "$file_path" "$file_url"
-            
-            if [ ! -e "$file_path" ]; then
-                build_infoPanel "Sync Failed"  "Failed to download the $file_type file." 
+			local file_size=$(stat -c%s "$file_path")
+			local file_chksum_actual
+
+			if [ "$file_size" -gt "$MAX_FILE_SIZE_BYTES" ]; then
+				file_chksum_actual=$file_size
+			else
+				file_chksum_actual=$(cksum "$file_path" | awk '{ print $1 }')
+			fi
+
+			if [ "$file_checksum" -ne "$file_chksum_actual" ]; then
+				build_infoPanel_and_log "Checksum Mismatch" "The Rom exists but the checksum doesn't match \n Cannot continue."
+                notify_peer "stop_now"
+                sleep 2
                 cleanup
-            else
-                build_infoPanel "Syncing"  "$file_type synced." 
-            fi
-
-        else
-            log "GLO::Pokemon_Netplay: $file_path exists and the checksum matches."
-        fi
-    else
-        build_infoPanel "Syncing"  "$file_type doesn't exist locally; syncing with host." 
-        log "GLO::Pokemon_Netplay: $file_path doesn't exist. Syncing."
-        do_sync_file "$file_type" "$file_path" "$file_url"
-        
-        if [ ! -e "$file_path" ]; then
-            build_infoPanel "Sync Failed"  "Failed to download the $file_type file." 
+			else
+				build_infoPanel_and_log "Rom Check Complete!" "Rom exists and checksums match!"
+			fi
+		else
+			build_infoPanel_and_log "Rom Missing" "A rom requested doesn't exist on the local client \n Cannot continue."
+            notify_peer "stop_now"
+            sleep 2
             cleanup
-        else
-            build_infoPanel "Syncing"  "$file_type synced." 
-        fi
-    fi
+		fi
+	else
+		if [ -e "$file_path" ]; then
+			log "GLO::Pokemon_Netplay: $file_path exists."
+
+			local file_size=$(stat -c%s "$file_path")
+			local file_chksum_actual
+
+			if [ "$file_size" -gt "$MAX_FILE_SIZE_BYTES" ]; then
+				file_chksum_actual=$file_size
+			else
+				file_chksum_actual=$(cksum "$file_path" | awk '{ print $1 }')
+			fi
+
+			if [ "$file_checksum" -ne "$file_chksum_actual" ]; then
+				build_infoPanel_and_log "Syncing" "$file_type checksums don't match, syncing"
+				sleep 0.5
+				do_sync_file "$file_type" "$file_path" "$file_url"
+
+				if [ ! -e "$file_path" ]; then
+					build_infoPanel_and_log "Sync Failed" "Failed to download the $file_type file."
+                    notify_peer "stop_now"
+                    sleep 2
+					cleanup
+				else
+					build_infoPanel_and_log "Syncing" "$file_type synced."
+				fi
+
+			else
+				build_infoPanel_and_log "$file_type synced!" "$file_type checksums match, no sync required"
+			fi
+		else
+			build_infoPanel_and_log "Syncing" "$file_type doesn't exist locally; syncing with host."
+			do_sync_file "$file_type" "$file_path" "$file_url"
+
+			if [ ! -e "$file_path" ]; then
+				build_infoPanel_and_log "Sync Failed" "Failed to download the $file_type file."
+                notify_peer "stop_now"
+                sleep 2
+				cleanup
+			else
+				build_infoPanel_and_log "Syncing" "$file_type synced."
+			fi
+		fi
+	fi
 }
 
 # We'll need FTP to transfer files
@@ -461,28 +503,39 @@ flag_enabled() {
     [ -f "$sysdir/config/.$flag" ]
 }
 
-build_infoPanel() {
-    local title="$1"
-    local message="$2"
-    
-    infoPanel --title "$title" --message "$message" --persistent &
-    touch /tmp/dismiss_info_panel
-    sync
-    sleep 0.5
+build_infoPanel_and_log() {
+	local title="$1"
+	local message="$2"
+
+	if [ $LOGGING -eq 1 ]; then
+		echo "$(date) GLO::Pokemon_Netplay: Stage: $title Message: $message" >> $sysdir/logs/easy_netplay.log
+	fi
+	
+	infoPanel --title "$title" --message "$message" --persistent &
+	touch /tmp/dismiss_info_panel
+	sync
+	sleep 0.5
+}
+
+log() {
+	if [ $LOGGING -eq 1 ]; then
+    	echo "$(date)" $* >> $sysdir/logs/pokemon_link.log
+	fi
 }
 
 confirm_join_panel() {
     local title="$1"
     local message="$2"
     
+    sync
+        
     infoPanel -t "$title" -m "$message"
     retcode=$?
 
     echo "retcode: $retcode"
 
     if [ $retcode -ne 0 ]; then
-        build_infoPanel "Cancelled" "User cancelled, exiting."
-        log "GLO::Pokemon_Netplay: Cancelled by user"
+        build_infoPanel_and_log "Cancelled" "User cancelled, exiting."
         cleanup
         exit 1
     fi
@@ -568,19 +621,13 @@ udhcpc_control() {
 	if is_running udhcpc; then
 		log "GLO::Pokemon_Netplay: DHCP started"
 	else
-		build_infoPanel "DHCP" "Unable to start DHCP client\n unable to continue."
+		build_infoPanel_and_log "DHCP" "Unable to start DHCP client\n unable to continue."
 	fi
 }
 
 is_running() {
     process_name="$1"
     pgrep "$process_name" > /dev/null
-}
-
-log() {
-	if [ $LOGGING -eq 1 ]; then
-    	echo "$(date)" $* >> $sysdir/logs/pokemon_link.log
-	fi
 }
 
 
@@ -599,8 +646,9 @@ lets_go() {
     read_cookie
     send_saves
     backup_save
-    sync_file Rom "$rom" "$romchksum" "$rom_url"
-    sync_file Core "$core" "$corechksum" "$core_url"
+    sync_file Rom "$local_rom" # Doesn't sync anything, just uses the sync function to confirm it exists locally
+    sync_file Rom "$rom" "$romcheck" "$rom_url"
+    sync_file Core "$core" "$corecheck" "$core_url"
     stripped_game_name
     wait_for_host
     confirm_join_panel "Join now?" "Start the game on the host first! \n $game_name \n $game_name_client"

--- a/static/build/.tmp_update/script/easynetplay/pokemon_client.sh
+++ b/static/build/.tmp_update/script/easynetplay/pokemon_client.sh
@@ -128,7 +128,6 @@ download_cookie() {
 # Read the cookie and store the paths and checksums into a var.
 read_cookie() {
     check_stop
-	sync
 	while IFS= read -r line; do
 		case $line in
 			"[core]: "*)
@@ -216,12 +215,13 @@ backup_save() {
 
 # Wait for the host to tell us it's ready, this happens just before it starts its RA session and we look in /tmp for a file indicator (file removed in host script cleanup)
 wait_for_host() {
-    check_stop
+    
     local counter=0
 
     build_infoPanel_and_log "Ready" "Waiting for host to ready up"
     while true; do
         sync
+        check_stop
         for file in /tmp/host_ready; do
             if [ -f "$file" ]; then
                 build_infoPanel_and_log "Message from host" "Setup complete"
@@ -274,7 +274,6 @@ change_tgb_dual_opt() {
 # We'll start Retroarch in host mode with -H with the core and rom paths loaded in.
 start_retroarch() {
     check_stop
-    sync
 	build_infoPanel_and_log "RetroArch" "Starting RetroArch..."
     log "GLO::Pokemon_Netplay: Starting RetroArch loaded with $rom and $local_rom"
 	cd /mnt/SDCARD/RetroArch
@@ -381,6 +380,7 @@ notify_stop(){
 
 # Check stop, if the client tells us to stop we will.
 check_stop(){
+    sync
     if [ -e "/tmp/stop_now" ]; then
             build_infoPanel_and_log "Message from client" "The host has had a problem setting up the session"
             sleep 2

--- a/static/build/.tmp_update/script/easynetplay/pokemon_server.sh
+++ b/static/build/.tmp_update/script/easynetplay/pokemon_server.sh
@@ -19,10 +19,8 @@ rm /tmp/stop_now
 
 check_wifi() {
 	if ifconfig wlan0 &>/dev/null; then
-		log "GLO::Pokemon_Netplay: Wi-Fi is up already"
 		build_infoPanel_and_log "WIFI" "Wifi up"
 	else
-		log "GLO::Pokemon_Netplay: Wi-Fi disabled, trying to enable before connecting.."
 		build_infoPanel_and_log "WIFI" "Wifi disabled, starting..." 
 		
 		/customer/app/axp_test wifion
@@ -33,10 +31,8 @@ check_wifi() {
         udhcpc_control
 		
 		if is_running wpa_supplicant && ifconfig wlan0 > /dev/null 2>&1; then
-			log "GLO::Pokemon_Netplay: WiFi started"
 			build_infoPanel_and_log "WIFI" "Wifi started."
 		else
-			log "GLO::Pokemon_Netplay: WiFi started"
 			build_infoPanel_and_log "WIFI" "Unable to start WiFi\n unable to continue."
 			notify_stop
 		fi

--- a/static/build/.tmp_update/script/easynetplay/pokemon_server.sh
+++ b/static/build/.tmp_update/script/easynetplay/pokemon_server.sh
@@ -281,8 +281,7 @@ read_cookie() {
 # Duplicate the rom to spoof the save loaded in on the host
 handle_roms() {
     check_stop
-    sync
-
+    
     rom_extension="${client_rom##*.}"
     client_rom_clone="${client_rom%.*}_client.$rom_extension"
     cp "$client_rom" "$client_rom_clone"
@@ -339,8 +338,7 @@ change_tgb_dual_opt() {
 
 # We'll start Retroarch in host mode with -H with the core and rom paths loaded in.
 start_retroarch() {
-    check_stop
-    sync   
+    check_stop 
 	build_infoPanel_and_log "RetroArch" "Starting RetroArch..."
     log "GLO::Pokemon_Netplay: Starting RetroArch loaded with $host_rom and $client_rom_clone"
 	cd /mnt/SDCARD/RetroArch
@@ -443,6 +441,7 @@ notify_stop(){
 
 # Check stop, if the client tells us to stop we will.
 check_stop(){
+    sync
     if [ -e "/tmp/stop_now" ]; then
             build_infoPanel_and_log "Message from client" "The client has had a problem joining the session."
             sleep 2


### PR DESCRIPTION
Added stop notification/checks on both host and client to catch problems at any step.
Check whether the rom disappears after the client hits the join button (this should never happen)
File checks reworked
Logging reworked
More logging added
Remove unnecessary exports
Add notification to Pokemon Host/Client scripts to stop before the confirm panel if critical files are not synced
General refactors (duplicate actions become functions)
Added sleeps to allow for more time reading infopanels
Added sleep to allow hostapd to work before (in rare cases) reporting it has failed and is retrying (but still succeeding)