### PR TITLE
FEAT: Added tool to automatically generate miyoogamelists with clean names

### DIFF
--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -555,6 +555,10 @@ void menu_tools(void *_)
                      (ListItem){
                          .label = "Generate game list for short name roms",
                          .action = tool_buildShortRomGameList});
+        list_addItem(&_menu_tools,
+                     (ListItem){
+                         .label = "Generate miyoogamelist with digest names",
+                         .action = tool_generateMiyoogamelists});
     }
     menu_stack[++menu_level] = &_menu_tools;
     header_changed = true;

--- a/src/tweaks/tools.h
+++ b/src/tweaks/tools.h
@@ -103,8 +103,14 @@ void tool_buildShortRomGameList(void *pt)
     _runCommandPopup(tools_short_names[6], "./bin/gameNameList /mnt/SDCARD /mnt/SDCARD/BIOS/arcade_lists");
 }
 
+void tool_generateMiyoogamelists(void *pt)
+{
+    _runCommandPopup(tools_short_names[7], "/mnt/SDCARD/.tmp_update/script/miyoogamelist_gen.sh");
+}
+
 static void (*tools_pt[NUM_TOOLS])(void *) = {
     tool_generateCueFiles,
-    tool_buildShortRomGameList};
+    tool_buildShortRomGameList,
+    tool_generateMiyoogamelists};
 
 #endif // TWEAKS_TOOLS_H__

--- a/src/tweaks/tools_defs.h
+++ b/src/tweaks/tools_defs.h
@@ -3,10 +3,11 @@
 
 #include "utils/str.h"
 
-#define NUM_TOOLS 2
+#define NUM_TOOLS 3
 
 static char tools_short_names[NUM_TOOLS][STR_MAX] = {
     "cue_gen",
-    "build_short_rom_game_list"};
+    "build_short_rom_game_list",
+    "miyoogamelist_gen"};
 
 #endif // TWEAKS_TOOLS_DEFS_H__

--- a/static/build/.tmp_update/script/miyoogamelist_gen.sh
+++ b/static/build/.tmp_update/script/miyoogamelist_gen.sh
@@ -3,12 +3,28 @@
 rootdir="/mnt/SDCARD/Emu"
 out='miyoogamelist.xml'
 
+clean_name() {
+    # move article to the start of the name, if present
+    article=$(echo "$1" | sed -e 's/.*, \(A\|The\|An\).*/\1/')
+    name="$article $(echo "$1" | sed -e 's/, \(A\|The\|An\)//')"
+
+    # change " - " to ": " for subtitles
+    name=$(echo "$name" | sed -e 's/ - /: /')
+
+    # remove everything in brackets
+    name=$(echo "$name" | sed -e 's/(.*)//')
+    name=$(echo "$name" | sed -e 's/\[.*\]//')
+
+    # trim
+    echo "$name" | awk '{$1=$1};1'
+}
+
 generate_miyoogamelist() {
     rompath=$1
     imgpath=$2
     extlist=$3
 
-    cd $rompath
+    cd "$rompath"
 
     # create backup of previous miyoogamelist.xml
     if [ -f "$out" ]; then
@@ -31,7 +47,7 @@ generate_miyoogamelist() {
         fi
 
         filename="${rom%.*}"
-        digest=$(echo "$rom" | grep -oE "^([^(\[]*)" | awk '{$1=$1};1')
+        digest=$(clean_name "$filename")
 
         cat <<EOF >>$out
     <game>

--- a/static/build/.tmp_update/script/miyoogamelist_gen.sh
+++ b/static/build/.tmp_update/script/miyoogamelist_gen.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+rootdir="/mnt/SDCARD/Roms"
+out='miyoogamelist.xml'
+
+generate_miyoogamelist() {
+    # create backup of previous miyoogamelist.xml
+    if [ -f "$out" ]; then
+        mv "$out" "$out.bak"
+    fi
+
+    echo '<?xml version="1.0"?>' >$out
+    echo '<gameList>' >>$out
+
+    for rom in *; do
+        # ignore subfolders because miyoogamelist don't work with them
+        # also ignores Imgs folder, nice
+        if [ -d "$rom" ]; then
+            continue
+        fi
+
+        # .xml, .bak & .db files are no games
+        # .bin files are no games, .cue files are!
+        if echo "$rom" | grep -qE "\.(xml|bak|db|bin)$"; then
+            continue
+        fi
+
+        filename="${rom%.*}"
+        digest=$(echo "$rom" | grep -oE "^([^(]*)" | awk '{$1=$1};1')
+
+        cat <<EOF >>$out
+    <game>
+        <path>./$rom</path>
+        <name>$digest</name>
+        <image>./Imgs/$filename.png</image>
+    </game>
+EOF
+    done
+
+    echo '</gameList>' >>$out
+}
+
+for system in "$rootdir"/*; do
+    if [ -d "$system" ]; then
+        # ignore Arcades & Ports since they have their own gamelist already
+        if echo "$system" | grep -qE "(PORTS|FBA2012|FBNEO|MAME2000|ARCADE|NEOGEO|CPS1|CPS1|CPS3)"; then
+            continue
+        fi
+
+        cd "$system"
+        generate_miyoogamelist
+    fi
+done


### PR DESCRIPTION
Add a script/tool that generate `miyoogamelist.xml` for all systems (except Arcades).
I chose to exclude arcade titles because they have their own gamelist already.

In the process, it removes additional info from the name of the game, assuming the roms are names according to [No-Intro Naming Convention](https://wiki.no-intro.org/index.php?title=Naming_Convention).

Also, the script will backup existing `miyoogamelist.xml` files to  `miyoogamelist.xml.bak` in case the user add one already and avoid losing it.

~~There is room for improvement, for instance replacing " - " by ": " in names or moving back articles to the beginning o the name (ie: "Legend of Zelda, The" -> "The Legend of Zelda")~~ 
Edit: Articles (The, A, An) are moved to the start of the name (according to naming convention) and subtitles are separated using '": " instead of " - "