### PR TITLE
FIX: miyoogamelist_gen fix sed behavior on no-match & aggressive bracket regex

### DIFF
--- a/static/build/.tmp_update/script/miyoogamelist_gen.sh
+++ b/static/build/.tmp_update/script/miyoogamelist_gen.sh
@@ -11,6 +11,9 @@ clean_name() {
     name=$(echo "$name" | sed -e 's/([^)]*)//g')
     name=$(echo "$name" | sed -e 's/\[[^]]*\]//g')
 
+    # remove rankings
+    name=$(echo "$name" | sed -e 's/^[0-9]\+\.//')
+
     # trim
     name=$(echo "$name" | awk '{$1=$1};1')
 

--- a/static/build/.tmp_update/script/miyoogamelist_gen.sh
+++ b/static/build/.tmp_update/script/miyoogamelist_gen.sh
@@ -4,19 +4,27 @@ rootdir="/mnt/SDCARD/Emu"
 out='miyoogamelist.xml'
 
 clean_name() {
-    # move article to the start of the name, if present
-    article=$(echo "$1" | sed -ne 's/.*, \(A\|The\|An\).*/\1/p')
-    name="$article $(echo "$1" | sed -e 's/, \(A\|The\|An\)//')"
+    name="$1"
 
-    # change " - " to ": " for subtitles
-    name=$(echo "$name" | sed -e 's/ - /: /')
-
+    ### REMOVE NON-ESSENTIALS ###
     # remove everything in brackets
     name=$(echo "$name" | sed -e 's/([^)]*)//g')
     name=$(echo "$name" | sed -e 's/\[[^]]*\]//g')
 
     # trim
-    echo "$name" | awk '{$1=$1};1'
+    name=$(echo "$name" | awk '{$1=$1};1')
+
+    ### FORMAT ###
+    # move article to the start of the name, if present
+    article=$(echo "$name" | sed -ne 's/.*, \(A\|The\|An\).*/\1/p')
+    if [ ! -z $article ]; then
+        name="$article $(echo "$name" | sed -e 's/, \(A\|The\|An\)//')"
+    fi
+
+    # change " - " to ": " for subtitles
+    name=$(echo "$name" | sed -e 's/ - /: /')
+
+    echo "$name"
 }
 
 generate_miyoogamelist() {

--- a/static/build/.tmp_update/script/miyoogamelist_gen.sh
+++ b/static/build/.tmp_update/script/miyoogamelist_gen.sh
@@ -5,8 +5,14 @@ out='miyoogamelist.xml'
 
 clean_name() {
     name="$1"
+    extlist="$2"
 
     ### REMOVE NON-ESSENTIALS ###
+    # remove file extensions
+    while echo "$name" | grep -qE "\.($extlist)$"; do
+        name="${name%.*}"
+    done
+
     # remove everything in brackets
     name=$(echo "$name" | sed -e 's/([^)]*)//g')
     name=$(echo "$name" | sed -e 's/\[[^]]*\]//g')
@@ -58,7 +64,7 @@ generate_miyoogamelist() {
         fi
 
         filename="${rom%.*}"
-        digest=$(clean_name "$filename")
+        digest=$(clean_name "$rom" "$extlist")
 
         cat <<EOF >>$out
     <game>

--- a/static/build/.tmp_update/script/miyoogamelist_gen.sh
+++ b/static/build/.tmp_update/script/miyoogamelist_gen.sh
@@ -5,15 +5,15 @@ out='miyoogamelist.xml'
 
 clean_name() {
     # move article to the start of the name, if present
-    article=$(echo "$1" | sed -e 's/.*, \(A\|The\|An\).*/\1/')
+    article=$(echo "$1" | sed -ne 's/.*, \(A\|The\|An\).*/\1/p')
     name="$article $(echo "$1" | sed -e 's/, \(A\|The\|An\)//')"
 
     # change " - " to ": " for subtitles
     name=$(echo "$name" | sed -e 's/ - /: /')
 
     # remove everything in brackets
-    name=$(echo "$name" | sed -e 's/(.*)//')
-    name=$(echo "$name" | sed -e 's/\[.*\]//')
+    name=$(echo "$name" | sed -e 's/([^)]*)//g')
+    name=$(echo "$name" | sed -e 's/\[[^]]*\]//g')
 
     # trim
     echo "$name" | awk '{$1=$1};1'


### PR DESCRIPTION
When testing further name cleaning I found out 2 issues:
- On no-match `sed` return the string untouched, causing duplicate when no article is present in some cases, fixed by `-n` option combined with `/p` command
- The brackets regex was too agressive, it matched from the opening bracket to the **last** closing one, not the **next**