### PR TITLE
Update fr.lang - Fix error in translation for "language"

### DIFF
--- a/static/build/miyoo/app/lang/fr.lang
+++ b/static/build/miyoo/app/lang/fr.lang
@@ -23,7 +23,7 @@
 	"20": "ADC INFO",
 	"21": "EncDec Test",
 	"22": "Mappage Touches",
-	"23": "Langage",
+	"23": "Langue",
 	"24": "Volume",
 	"25": "Vol. fond sonore",
 	"26": "Luminosité",


### PR DESCRIPTION
In french, the correct word here is "langue" and not "langage".