### PR TITLE
FIX: Add migration script for hostapd.conf fix

### DIFF
--- a/static/build/.tmp_update/script/migration/00013_fix_hostapd_config.sh
+++ b/static/build/.tmp_update/script/migration/00013_fix_hostapd_config.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Fix for missing ctrl interface call in the config, will cause failures to some easynetplay features without this.
 
-hostapdconfdir=/mnt/SDCARD/.tmp_update/config/hostapd.conf
-if ! grep -q "ctrl_interface=/var/run/hostapd" $hostapdconfdir; then
-    sed -i '1ictrl_interface=/var/run/hostapd' $hostapdconfdir
+hostapd_conf=/mnt/SDCARD/.tmp_update/config/hostapd.conf
+if ! grep -q "ctrl_interface=/var/run/hostapd" $hostapd_conf; then
+    sed -i '1ictrl_interface=/var/run/hostapd' $hostapd_conf
 fi

--- a/static/build/.tmp_update/script/migration/00013_fix_hostapd_config.sh
+++ b/static/build/.tmp_update/script/migration/00013_fix_hostapd_config.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Fix for missing ctrl interface call in the config, will cause failures to some easynetplay features without this.
+
+hostapdconfdir=/mnt/SDCARD/.tmp_update/config/hostapd.conf
+if ! grep -q "ctrl_interface=/var/run/hostapd" $hostapdconfdir; then
+    sed -i '1ictrl_interface=/var/run/hostapd' $hostapdconfdir
+fi


### PR DESCRIPTION
Minor change.
## What:
PR to add a migration script to add the missing line to the top of the .conf file.
## Why:
Fixes "Hostapd hook failing" loop when trying to setup an easy netplay session for pokemon
## When:
Hostapd ctrl_interface was added in ENP PR to the conf, the conf won't get updated without a full install.
![image](https://github.com/OnionUI/Onion/assets/47260768/88669532-7b5e-4c0a-90cd-66c4b941e094)

![image](https://github.com/OnionUI/Onion/assets/47260768/b9129245-17bf-46af-9dbd-4b901853e7b8)

