### PR TITLE
FIX: Re-add missing logfiles from runtime.sh clear_logs function.

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -146,9 +146,10 @@ clear_logs() {
         ./gameSwitcher.log \
         ./keymon.log \
         ./game_list_options.log \
-        ./network.log \
         ./dnsmasq.log \
         ./ftp.log \
+        ./runtime.log \
+        ./update_networking.log \
         ./easy_netplay.log \
         2> /dev/null
 }


### PR DESCRIPTION
Very minor change.

The logging entries changed when the logging method was changed to a sourced script that uses the scripts name.

@schmurtzm should `scrap.log` also be added to this or are you keeping it over reboots??