### PR TITLE
DOCS: Added installation and upgrade instructions for Chrome OS

### DIFF
--- a/website/docs/01-getting-started/01-installation/01-fresh-install.mdx
+++ b/website/docs/01-getting-started/01-installation/01-fresh-install.mdx
@@ -63,6 +63,11 @@ Make sure you choose: `For use with all systems and devices (FAT)`
 
 
 </TabItem>
+<TabItem value="chromeos" label="Chrome OS">
+
+Chrome already has a tool to format an SD card. Insert the card into your Chromebook, right-click it and click **Format Device**, make sure `FAT32` is selected unser **Format** and click or tap **Erase & Format**. 
+
+</TabItem>
 </Tabs>
 
 
@@ -104,6 +109,13 @@ Make sure you choose: `For use with all systems and devices (FAT)`
    cp -r Onion-v4.2.0/* /run/media/mmcblk0p1
    ```
 
+
+</TabItem>
+<TabItem value="chromeos" label="Chrome OS">
+
+1. Double-click the `Onion-v4.x.x.zip` file. The contents of the file will be displayed.
+2. Make sure hidden files are visible by clicking or tapping the top-right corner 3-dots icon and making sure `Show Hidden Files` is toggled on.
+3. Copy the 7 folders to your SD card, dragging them into your SD card drive icon on the left panel.
 
 </TabItem>
 </Tabs>

--- a/website/docs/01-getting-started/01-installation/02-upgrading.mdx
+++ b/website/docs/01-getting-started/01-installation/02-upgrading.mdx
@@ -64,6 +64,18 @@ please **make sure to create in-game saves** before upgrading.
 
 
 </TabItem>
+<TabItem value="chromeos" label="Chrome OS">
+
+:::caution
+Due to limitations in the way the Chrome OS File Manager works, it's recommended to backup your personal files, perform a clean install of Onion OS on the SD card, and then restore your backed up files. The following instructions go through this procedure.
+:::
+
+1. Display the contents of the SD card on the File Manager by double-clicking the drive icon.
+2. Backup your personal files such as the ones under `Roms`, `BIOS`, `Saves` and `Themes` directories.
+3. Perform a [clean install](/installation/fresh) on the SD card.
+4. Restore your files on the newly installed Onion SD card. **Do not move a file to the same location as one with the same name**. This will cause the moved file to be duplicated with a number appended to it, and won't be recognized by Onion OS. 
+
+</TabItem>
 </Tabs>
 
 :::info

--- a/website/docs/01-getting-started/01-installation/02-upgrading.mdx
+++ b/website/docs/01-getting-started/01-installation/02-upgrading.mdx
@@ -72,7 +72,7 @@ Due to limitations in the way the Chrome OS File Manager works, it's recommended
 
 1. Display the contents of the SD card on the File Manager by double-clicking the drive icon.
 2. Backup your personal files such as the ones under `Roms`, `BIOS`, `Saves` and `Themes` directories.
-3. Perform a [clean install](/installation/fresh) on the SD card.
+3. Perform a [clean install](/docs/installation/fresh) on the SD card.
 4. Restore your files on the newly installed Onion SD card. **Do not move a file to the same location as one with the same name**. This will cause the moved file to be duplicated with a number appended to it, and won't be recognized by Onion OS. 
 
 </TabItem>


### PR DESCRIPTION
Added instructions for Chrome OS. Unfortunately, Chrome OS doesn't support overwriting or merging files when copying/moving them into a location with files with the same names, making the upgrade process much more difficult than it should be. I resorted to recommending doing a backup and performing a clean install instead.