### PR TITLE
Add a link to releases on installation page

### DIFF
--- a/website/docs/02-installation/index.mdx
+++ b/website/docs/02-installation/index.mdx
@@ -100,7 +100,7 @@ Download the latest version of Onion:
     <ReleaseLink label="Beta" showDownloads className="button button--secondary button--lg" url="https://api.github.com/repos/OnionUI/Onion/releases/tags/v4.2.0-rc" />
 </div>
 
-The Onion installation zip is found under **Assets** at the bottom of the release notes.  
+The Onion installation zip is found under **Assets** at the bottom of the [release notes](https://github.com/OnionUI/Onion/releases).  
 Look for `Onion-v4.x.x.zip` or `Onion-v4.x.x-snapshot-[tag].zip`.
 
 


### PR DESCRIPTION
Currently, there is no link or indication of where to go to download the Onion distribution. This changes the wording of "release notes" to be a link to the release page on Github.