### PR TITLE
FIX: Display settings not applying in 4.2.1

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -487,6 +487,8 @@ mount_main_ui() {
 init_system() {
     log "\n:: Init system"
 
+    load_settings
+
     # init_lcd
     cat /proc/ls
     sleep 0.25
@@ -496,8 +498,6 @@ init_system() {
     fi
 
     start_audioserver
-
-    load_settings
 
     brightness=$(/customer/app/jsonval brightness)
     brightness_raw=$(awk "BEGIN { print int(3 * exp(0.350656 * $brightness) + 0.5) }")


### PR DESCRIPTION
## Problem

The display init procedure looks at `/appconfigs/system.json` for the display values. This file was moved to `/mnt/SDCARD/system.json` in 4.2.1 - but the symlink from appconfigs was made *after* display init.

## Changes

- Moved the symlink creation above the display init in the runtime init procedure