### PR TITLE
Update 01-amstrad-cpc.md

### DIFF
--- a/website/docs/04-emulators/02-consoles/01-amstrad-cpc.md
+++ b/website/docs/04-emulators/02-consoles/01-amstrad-cpc.md
@@ -11,3 +11,10 @@ slug: /emulators/cpc
 - Rom Folder: `CPC`
 - Extensions: `.sna` `.dsk` `.kcr`
 - Bios: None
+
+Alternative Emulator:
+  
+- Emulator: Caprice32
+- Rom Folder: `CPC`
+- Extensions: `.dsk` `.sna` `.zip` `.tap` `.cdt` `.voc` `.cpr` `.m3u`
+- Bios: None


### PR DESCRIPTION
As Caprice32 use different extensions than crocods, probably is better to use a new field for it? 
It seems more readable. Let me know if it's ok, so i can modify others emulators, at same way :)

ps: i have wrote "Alternative Emulator" as i didn't find how to put a space between the two bulletted lists (preview doesn't show normal spaces).