### PR TITLE
FIX: exporter log entry location

### DIFF
--- a/static/build/.tmp_update/script/diagnostics/util_exporter.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_exporter.sh
@@ -33,7 +33,7 @@ exporter() {
     7z a -y "$filename" "$workingdir/*" >/dev/null 2>&1
 
     if [ -s "$filename" ]; then
-        log "Exported to: .tmp_update/log_export.7z"
+        log "Exported to: $filename"
         rm -rf $workingdir
     else
         log "Failed to export"


### PR DESCRIPTION
Fixes the location of the reported logfile dump

(util_exporter) 2023-09-25 13:12:17: Exported to: .tmp_update/log_export.7z

to

(util_exporter) 2023-09-25 13:09:17: Exported to: /mnt/SDCARD/log_export.7z