### PR TITLE
FEAT: App list sorting tool (asc/desc A-Z)

### DIFF
--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -692,6 +692,18 @@ void menu_tools(void *_)
                                  "This generates a 'miyoogamelist.xml' file\n"
                                  "which comes with some limitations, such\n"
                                  "as no subfolder support.");
+        list_addItemWithInfoNote(&_menu_tools,
+                                 (ListItem){
+                                     .label = "Sort applist A-Z",
+                                     .action = tool_sortAppsAZ},
+                                 "Use this tool to sort your App list\n"
+                                 "ascending from A to Z.\n");
+        list_addItemWithInfoNote(&_menu_tools,
+                                 (ListItem){
+                                     .label = "Sort applist Z-A",
+                                     .action = tool_sortAppZA},
+                                 "Use this tool to sort your App list\n"
+                                 "descending from Z to A.\n");
     }
     menu_stack[++menu_level] = &_menu_tools;
     header_changed = true;

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -701,7 +701,7 @@ void menu_tools(void *_)
         list_addItemWithInfoNote(&_menu_tools,
                                  (ListItem){
                                      .label = "Sort applist Z-A",
-                                     .action = tool_sortAppZA},
+                                     .action = tool_sortAppsZA},
                                  "Use this tool to sort your App list\n"
                                  "descending from Z to A.\n");
     }

--- a/src/tweaks/tools.h
+++ b/src/tweaks/tools.h
@@ -108,9 +108,21 @@ void tool_generateMiyoogamelists(void *pt)
     _runCommandPopup(tools_short_names[2], "/mnt/SDCARD/.tmp_update/script/miyoogamelist_gen.sh");
 }
 
+void tool_sortAppsAZ(void *pt)
+{
+    _runCommandPopup(tools_short_names[3], "/mnt/SDCARD/.tmp_update/script/app_sorter.sh");
+}
+
+void tool_sortAppsZA(void *pt)
+{
+    _runCommandPopup(tools_short_names[4], "/mnt/SDCARD/.tmp_update/script/app_sorter.sh desc");
+}
+
 static void (*tools_pt[NUM_TOOLS])(void *) = {
     tool_generateCueFiles,
     tool_buildShortRomGameList,
-    tool_generateMiyoogamelists};
+    tool_generateMiyoogamelists,
+    tool_sortAppsAZ,
+    tool_sortAppsZA};
 
 #endif // TWEAKS_TOOLS_H__

--- a/src/tweaks/tools_defs.h
+++ b/src/tweaks/tools_defs.h
@@ -3,11 +3,13 @@
 
 #include "utils/str.h"
 
-#define NUM_TOOLS 3
+#define NUM_TOOLS 5
 
 static char tools_short_names[NUM_TOOLS][STR_MAX] = {
     "cue_gen",
     "build_short_rom_game_list",
-    "miyoogamelist_gen"};
+    "miyoogamelist_gen",
+    "sort_apps_az",
+    "sort_apps_za"};
 
 #endif // TWEAKS_TOOLS_DEFS_H__

--- a/static/build/.tmp_update/script/app_sorter.sh
+++ b/static/build/.tmp_update/script/app_sorter.sh
@@ -33,9 +33,13 @@ sort_and_copy_back() {
 }
 
 cleanup() {
+    #restart mainui to refresh app list (if called from a button/script while main is running)
+    if pgrep "MainUI" > /dev/null; then
+        pkill -2 "MainUI"
+    fi
+
     rm -rf /mnt/SDCARD/App.temp
     rm "$temp_file"
-    killall -2 MainUI
 }
 
 main() {

--- a/static/build/.tmp_update/script/app_sorter.sh
+++ b/static/build/.tmp_update/script/app_sorter.sh
@@ -1,0 +1,49 @@
+create_temp_dir() {
+    mkdir -p /mnt/SDCARD/App.temp
+    for dir in /mnt/SDCARD/App/*/; do
+        if [ -f "$dir/config.json" ]; then
+            mv "$dir" /mnt/SDCARD/App.temp/
+        fi
+    done
+}
+
+read_and_store_labels() {
+    temp_file="/mnt/SDCARD/temp_labels.txt"
+    : > "$temp_file"
+
+    for dir in /mnt/SDCARD/App.temp/*/; do
+        if [ -f "$dir/config.json" ]; then
+            label=$(awk -F'"' '/"label":/ {print $4}' "$dir/config.json")
+            echo "$label:$dir" >> "$temp_file"
+        fi
+    done
+}
+
+sort_and_copy_back() {
+    sort_order="$1"
+    if [ "$sort_order" = "desc" ]; then
+        sort_flag="-rf"
+    else
+        sort_flag="-f"
+    fi
+
+    sort $sort_flag "$temp_file" | while IFS=: read -r label dir; do
+        mv "$dir" /mnt/SDCARD/App/
+    done
+}
+
+cleanup() {
+    rm -rf /mnt/SDCARD/App.temp
+    rm "$temp_file"
+    killall -2 MainUI
+}
+
+main() {
+    sort_order="${1:-asc}"
+    create_temp_dir
+    read_and_store_labels
+    sort_and_copy_back "$sort_order"
+    cleanup
+}
+
+main "$@"


### PR DESCRIPTION
## Needs to be merged after Mainui sig handling #1193 as it uses -2, and #1299 unless rebased after this merges (as the NUM_TOOLS needs to be updated)

- Tested on MM+ FW 0628, MM 1027, MM 0611
- Tested with Sandisk Ultra cards

## Adds a tool to sort the Apps list A-Z or Z-A based on their config.json LABEL. 

- Will add 2 tools to the Tweaks -> Tools menu
