### PR TITLE
DOCS: Update cp command on 02-upgrading.mdx

### DIFF
--- a/website/docs/02-installation/02-upgrading.mdx
+++ b/website/docs/02-installation/02-upgrading.mdx
@@ -54,7 +54,7 @@ please **make sure to create in-game saves** before upgrading.
 2. Copy the 7 folders to your SD card, using the following command (replace `/run/media/mmcblk0p1` with the path to your SD card):
 
    ```sh
-   /bin/cp -rf Onion-v4.2.0/* /run/media/mmcblk0p1
+   /bin/cp -rfv Onion-v4.2.0/* /run/media/mmcblk0p1
    ```
 
 </TabItem>

--- a/website/docs/02-installation/02-upgrading.mdx
+++ b/website/docs/02-installation/02-upgrading.mdx
@@ -54,7 +54,7 @@ please **make sure to create in-game saves** before upgrading.
 2. Copy the 7 folders to your SD card, using the following command (replace `/run/media/mmcblk0p1` with the path to your SD card):
 
    ```sh
-   cp -rf Onion-v4.2.0/* /run/media/mmcblk0p1
+   /bin/cp -rf Onion-v4.2.0/* /run/media/mmcblk0p1
    ```
 
 </TabItem>


### PR DESCRIPTION
Hello all, 

Proposed change is to update `cp` command on linux tab as most linux distros have cp aliased to ask for overwriting the file `cp -i` so you would have to type <y> in all overwrite commands and enter. By adding the absolute path we are bypassing the alias found on the terminal. This can also be achieved with `yes | cp -rf  <source> <destination>` but its probably not the best option.  Adding `/bin/cp -rfv <source> <destination>` shows progress and replaces without prompt interaction.

Below I added some examples of the proposed change 

```sh
# example showing alias and executing the command which requires saying yes on all prompts
$ alias cp
alias cp='cp -iv'

$ cp -rf Onion-v4.2.3/* /run/media/pc/2241-B208/
cp: overwrite '/run/media/pc/2241-B208/BIOS/capsimg.so'? y
'Onion-v4.2.3/BIOS/capsimg.so' -> '/run/media/pc/2241-B208/BIOS/capsimg.so'
cp: overwrite '/run/media/pc/2241-B208/BIOS/.advance/ARCADE.lst'? y
'Onion-v4.2.3/BIOS/.advance/ARCADE.lst' -> '/run/media/pc/2241-B208/BIOS/.advance/ARCADE.lst'
cp: overwrite '/run/media/pc/2241-B208/BIOS/.advance/AdvanceMAME.xml'? y
```

```sh
# Adding absolute path /bin/cp overwrites the alias and works as expected without interactive prompt

$ /bin/cp -rfv Onion-v4.2.3/* /run/media/pc/2241-B208/
'Onion-v4.2.3/BIOS/capsimg.so' -> '/run/media/pc/2241-B208/BIOS/capsimg.so'
'Onion-v4.2.3/BIOS/.advance/ARCADE.lst' -> '/run/media/pc/2241-B208/BIOS/.advance/ARCADE.lst'
'Onion-v4.2.3/BIOS/.advance/AdvanceMAME.xml' -> '/run/media/pc/2241-B208/BIOS/.advance/AdvanceMAME.xml'
'Onion-v4.2.3/BIOS/.advance/BinggraeMelona.ttf' -> '/run/media/pc/2241-B208/BIOS/.advance/BinggraeMelona.ttf'
'Onion-v4.2.3/BIOS/.advance/Default configuration files.7z' -> '/run/media/pc/2241-B208/BIOS/.advance/Default configuration files.7z'
'Onion-v4.2.3/BIOS/.advance/NEOGEO.lst' -> '/run/media/pc/2241-B208/BIOS/.advance/NEOGEO.lst'
<omitted>
...
```