### PR TITLE
FEAT: Add option to disable time restore

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -581,6 +581,10 @@ save_settings() {
 }
 
 update_time() {
+    # Give hardware modders an option to disable time restore
+    if [ -f $sysdir/config/.noTimeRestore ]; then
+        return
+    fi
     timepath=/mnt/SDCARD/Saves/CurrentProfile/saves/currentTime.txt
     currentTime=0
     # Load current time


### PR DESCRIPTION
This is for the 5 people who are crazy and/or skilled enough to do the RTC mod.

Normally, Onion saves the system time at shutdown and restores it on bootup. This disables the restore part.

Since it would be a useless/confusing option for 99.9% of users it has to be enabled by manually creating the file 
`SD:/.tmp_update/config/.noTimeRestore`

Motivated to finally include this by #1334 