### PR TITLE
FIX: fix hint no screenshoot images after back from first image

### DIFF
--- a/static/packages/App/Gallery (Screenshot viewer)/App/Screenshots_Viewer/launch.sh
+++ b/static/packages/App/Gallery (Screenshot viewer)/App/Screenshots_Viewer/launch.sh
@@ -4,6 +4,9 @@ echo ":: Gallery - Screenshots Viewer ::"
 /mnt/SDCARD/.tmp_update/bin/infoPanel -d /mnt/SDCARD/Screenshots --show-theme-controls
 ec=$?
 
-if [ $ec -ne 0 ]; then
-    /mnt/SDCARD/.tmp_update/bin/infoPanel -t Gallery -m "No screenshots found"
+# cancel or success from infoPanel
+if [ $ec -eq 255 ] || [ $ec -eq 0 ] ; then
+    exit 0
 fi
+
+/mnt/SDCARD/.tmp_update/bin/infoPanel -t Gallery -m "No screenshots found"


### PR DESCRIPTION
Exit from gallery when existing images will return code 255, that cause a error hint, but do not need it actually.