### PR TITLE
FIX: Add migration script for res_exception

### DIFF
--- a/static/build/.tmp_update/script/migration/00018_res_exception.sh
+++ b/static/build/.tmp_update/script/migration/00018_res_exception.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# 560p beta testers had a different res_exception file
+# If the file does not contain "/mnt/SDCARD/App/" we need to reset it
+
+RESET_CONFIGS_PAK="/mnt/SDCARD/.tmp_update/config/configs.pak"
+
+if ! grep -qF "/mnt/SDCARD/App/" /mnt/SDCARD/.tmp_update/config/res_exceptions; then
+    echo "Resetting res_exceptions"
+    if 7z x -aoa "$RESET_CONFIGS_PAK" -o/mnt/SDCARD/ -ir!.tmp_update/config/res_exceptions; then
+        echo "Extraction successful."
+    else
+        echo "Error during extraction. Exit code: $?"
+    fi
+else
+    echo "Don't need to reset res_exceptions"
+fi


### PR DESCRIPTION
Needed by 560p beta testers who had a different res_exception file

With their file, some apps like EasyLogoTweak wouldn't work correctly.