### PR TITLE
FIX: bgm_mute setting gets deleted by MainUI

### DIFF
--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -25,7 +25,7 @@ typedef struct settings_s {
     int volume;
     char keymap[JSON_STRING_LEN];
     int mute;
-    int bgm_mute;
+    bool bgm_mute;
     int bgm_volume;
     int brightness;
     char language[JSON_STRING_LEN];
@@ -79,7 +79,6 @@ static settings_s __default_settings = (settings_s){
     .volume = 20,
     .keymap = "L2,L,R2,R,X,A,B,Y",
     .mute = 0,
-    .bgm_mute = 0,
     .bgm_volume = 20,
     .brightness = 7,
     .language = "en.lang",
@@ -93,6 +92,7 @@ static settings_s __default_settings = (settings_s){
     .audiofix = 1,
     .wifi_on = 0,
     // Onion settings
+    .bgm_mute = false,
     .show_recents = false,
     .show_expert = false,
     .startup_auto_resume = true,
@@ -169,7 +169,6 @@ void _settings_load_mainui(void)
 
     json_getInt(json_root, "vol", &settings.volume);
     json_getInt(json_root, "bgmvol", &settings.bgm_volume);
-    json_getInt(json_root, "bgmmute", &settings.bgm_mute);
     json_getInt(json_root, "brightness", &settings.brightness);
     json_getInt(json_root, "hibernate", &settings.sleep_timer);
     json_getInt(json_root, "lumination", &settings.lumination);
@@ -197,6 +196,7 @@ void settings_load(void)
 
     settings.startup_auto_resume = !config_flag_get(".noAutoStart");
     settings.menu_button_haptics = !config_flag_get(".noMenuHaptics");
+    settings.bgm_mute = config_flag_get(".bgmMute");
     settings.show_recents = config_flag_get(".showRecents");
     settings.show_expert = config_flag_get(".showExpert");
     settings.mute = config_flag_get(".muteVolume");
@@ -284,7 +284,6 @@ bool _settings_dirty_mainui(void)
     return settings.volume != __settings.volume ||
            strcmp(settings.keymap, __settings.keymap) != 0 ||
            settings.mute != __settings.mute ||
-           settings.bgm_mute != __settings.bgm_mute ||
            settings.bgm_volume != __settings.bgm_volume ||
            settings.brightness != __settings.brightness ||
            strcmp(settings.language, __settings.language) != 0 ||
@@ -315,7 +314,6 @@ void _settings_save_mainui(void)
     fprintf(fp, JSON_FORMAT_TAB_NUMBER, "vol", settings.volume);
     fprintf(fp, JSON_FORMAT_TAB_STRING, "keymap", settings.keymap);
     fprintf(fp, JSON_FORMAT_TAB_NUMBER, "mute", settings.mute);
-    fprintf(fp, JSON_FORMAT_TAB_NUMBER, "bgmmute", settings.bgm_mute);
     fprintf(fp, JSON_FORMAT_TAB_NUMBER, "bgmvol", settings.bgm_volume);
     fprintf(fp, JSON_FORMAT_TAB_NUMBER, "brightness", settings.brightness);
     fprintf(fp, JSON_FORMAT_TAB_STRING, "language", settings.language);
@@ -339,6 +337,7 @@ void settings_save(void)
 {
     config_flag_set(".noAutoStart", !settings.startup_auto_resume);
     config_flag_set(".noMenuHaptics", !settings.menu_button_haptics);
+    config_flag_set(".bgmMute", settings.bgm_mute);
     config_flag_set(".showRecents", settings.show_recents);
     config_flag_set(".showExpert", settings.show_expert);
     config_flag_set(".muteVolume", settings.mute);

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -587,12 +587,11 @@ get_screen_resolution() {
 }
 
 mute_theme_bgm() {
-    bgm_muted=$(/customer/app/jsonval bgmmute)
     system_theme="$(/customer/app/jsonval theme)"
     bgm_file="${system_theme}sound/bgm.mp3"
     muted_bgm_file="${system_theme}sound/bgm_muted.mp3"
 
-    if [ $bgm_muted -eq 1 ]; then
+    if [ -f "$sysdir/config/.bgmMute" ]; then
         if [[ -f "$bgm_file" ]]; then
             mv -f "$bgm_file" "$muted_bgm_file"
         fi


### PR DESCRIPTION
Moved bgm_mute setting out of system.json into $sysdir/config/

Background:

Whenever MainUI writes to system.json it clears out the whole file and rewrites it. This deletes the additional bgm_vol key out of system.json.

For example, if you were to mute the background music, then change the menu sound in MainUI settings, the bgm_vol key would be deleted from system.json and the background music would play.