### PR TITLE
FIX: Replace global resolution blacklist with a per-game/app whitelist file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,4 +14,3 @@ static/dist/miyoo354/app/MainUI text eol=lf
 static/build/.tmp_update/bin/shutdown text eol=lf
 static/configs/.tmp_update/config/passwd text eol=lf
 static/configs/.tmp_update/config/group text eol=lf
-static/configs/.tmp_update/config/res_exceptions text eol=lf

--- a/.github/create_fullres_files.sh
+++ b/.github/create_fullres_files.sh
@@ -6,7 +6,7 @@
 # Include hidden folders
 shopt -s dotglob
 
-packages="/root/workspace/build/App/PackageManager/data"
+packages="./build/App/PackageManager/data"
 
 # Emulators using RetroArch
 for dir in "$packages"/{Emu,RApp}/*/{Emu,RApp}/*/; do

--- a/.github/create_fullres_files.sh
+++ b/.github/create_fullres_files.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Creates full_resolution files where appropriate
+# If this file is present, the program will be launched in 560p by runtime.sh
+
+# Include hidden folders
+shopt -s dotglob
+
+packages="/root/workspace/build/App/PackageManager/data"
+
+# Emulators using RetroArch
+for dir in "$packages"/{Emu,RApp}/*/{Emu,RApp}/*/; do
+    if [ -f "${dir}launch.sh" ] && grep -qF "retroarch" "${dir}launch.sh"; then
+        touch "${dir}full_resolution"
+    fi
+done
+
+# DraStic
+touch "$packages/Emu/Nintendo - DS (Drastic)/Emu/NDS/full_resolution"
+
+# RetroArch shortcut
+touch "$packages/App/RetroArch (Shortcut)/App/RetroArch/full_resolution"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 TARGET=Onion
 VERSION=4.3.0-beta
-RA_SUBVERSION=1.15.0.8
+RA_SUBVERSION=1.15.0.9
 
 ###########################################################
 

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ $(CACHE)/.setup:
 	@$(STATIC_PACKAGES)/common/apply.sh "$(PACKAGES_RAPP_DEST)"
 	@$(STATIC_PACKAGES)/common/auto_advmenu_rc.sh "$(PACKAGES_EMU_DEST)" "$(TEMP_DIR)/configs/BIOS/.advance/advmenu.rc"
 	@$(STATIC_PACKAGES)/common/auto_advmenu_rc.sh "$(PACKAGES_RAPP_DEST)" "$(TEMP_DIR)/configs/BIOS/.advance/advmenu.rc"
+# Create full_resolution files
+	@chmod a+x $(ROOT_DIR)/.github/create_fullres_files.sh && $(ROOT_DIR)/.github/create_fullres_files.sh
 # Set flag: finished setup
 	@touch $(CACHE)/.setup
 

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -379,25 +379,24 @@ launch_game() {
             # GAME LAUNCH
 
             if [ -f /tmp/new_res_available ]; then
-                # check for games that don't work with 752x560 resolution
-                exceptions_file="$sysdir/config/res_exceptions"
-                exception_found=false
-                while IFS= read -r exception; do
-                    case "$exception" in
-                        ""|\#*)
-                            continue
-                            ;;
-                    esac
-                    if grep -qF "$exception" $sysdir/cmd_to_run.sh; then
-                        exception_found=true
-                        log "exception found: $exception"
-                        break
-                    fi
-                done < "$exceptions_file"
-                if ! $exception_found ; then
+                # Check if the program to be launched supports 560p
+                # This is determined by looking for a file "full_resolution" in the same directory as the launch script 
+
+                if grep -qF "/mnt/SDCARD/App/" $sysdir/cmd_to_run.sh; then
+                    # App launch scripts look different from game launch scripts
+                    full_resolution_path=$(cat $sysdir/cmd_to_run.sh | cut -d' ' -f 2 | sed 's/;/\/full_resolution/')
+                else
+                    full_resolution_path=$(grep -o '".*launch\.sh"' $sysdir/cmd_to_run.sh | sed 's/"//g' | sed 's/launch\.sh/full_resolution/')
+                fi
+
+                if [ -f "$full_resolution_path" ]; then
+                    log "Screen and program to be launched support 560p"
                     change_resolution
+                else
+                    log "Screen supports 560p, but program to be launched does not"
                 fi
             fi
+
             # Free memory
             $sysdir/bin/freemma
             cd /mnt/SDCARD/RetroArch/

--- a/static/configs/.tmp_update/config/res_exceptions
+++ b/static/configs/.tmp_update/config/res_exceptions
@@ -1,4 +1,0 @@
-# each line is matched against cmd_to_run.sh and if it matches, the resolution is not changed to 560p
-# blank lines and lines starting with # are ignored
-
-/mnt/SDCARD/App/


### PR DESCRIPTION
Replace the central res_exceptions file, which had a list of strings run against cmd_to_run.sh, with a per-program approach.
If a game/app wants to launch in 560p, it needs a file `full_resolution` next to it's launch.sh. 

This has multiple benefits, for example

- No need to iterate over a growing file on each game/app launch
- a user can easily remove or add the file if needed

A drawback would be that this is more of a whitelist approach, so for every system/app/game which can run in 560p, the according file must be created.
This is done at build time by the newly added script [create_fullres_files.sh](https://github.com/OnionUI/Onion/compare/replace-blacklist-with-something-better#diff-bca2ea91900785aa120dd3ba50be7f10f914e7b43acd0f6600b6a6a66df2fec6) 