### PR TITLE
FIX: 560p improvements

### DIFF
--- a/.github/create_fullres_files.sh
+++ b/.github/create_fullres_files.sh
@@ -8,15 +8,5 @@ shopt -s dotglob
 
 packages="./build/App/PackageManager/data"
 
-# Emulators using RetroArch
-for dir in "$packages"/{Emu,RApp}/*/{Emu,RApp}/*/; do
-    if [ -f "${dir}launch.sh" ] && grep -qF "retroarch" "${dir}launch.sh"; then
-        touch "${dir}full_resolution"
-    fi
-done
-
 # DraStic
 touch "$packages/Emu/Nintendo - DS (Drastic)/Emu/NDS/full_resolution"
-
-# RetroArch shortcut
-touch "$packages/App/RetroArch (Shortcut)/App/RetroArch/full_resolution"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 TARGET=Onion
 VERSION=4.3.0-beta
-RA_SUBVERSION=1.15.0.10
+RA_SUBVERSION=1.15.0.11
 
 ###########################################################
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 TARGET=Onion
 VERSION=4.3.0-beta
-RA_SUBVERSION=1.15.0.11
+RA_SUBVERSION=1.15.0.12
 
 ###########################################################
 
@@ -261,7 +261,7 @@ with-toolchain: $(CACHE)/.docker
 patch:
 	@chmod a+x $(ROOT_DIR)/.github/create_patch.sh && $(ROOT_DIR)/.github/create_patch.sh
 
-lib:
+external-libs:
 	@cd $(ROOT_DIR)/include/cJSON && make clean && make
 	@cd $(ROOT_DIR)/include/SDL && make clean && make
 

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -417,15 +417,9 @@ launch_game() {
             # GAME LAUNCH
 
             # Change resolution if needed
-            if [ -f /tmp/new_res_available ]; then
-                if [ -f "$full_resolution_path" ]; then
-                    log "Found full_resolution file, changing resolution to 560p"
-                    change_resolution
-                else
-                    log "No full_resolution file found"
-                fi
-            else
-                log "Screen does not support 560p"
+            if [ -f /tmp/new_res_available ] && [ -f "$full_resolution_path" ]; then
+                log "Found full_resolution file, changing resolution to 560p"
+                change_resolution
             fi
 
             # Free memory

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -338,7 +338,7 @@ launch_game() {
     if [ -f /tmp/new_res_available ]; then
         # Check if the program to be launched supports 560p
         # Different programs need different checks (Apps vs Ports vs the rest)
-
+        full_resolution_path=""
         if grep -qF "/mnt/SDCARD/App/" $sysdir/cmd_to_run.sh; then
             # ----- App launch ----- #
 
@@ -349,23 +349,16 @@ launch_game() {
 
             dot_port_path=$(grep -o '\/mnt\/SDCARD\/Roms\/PORTS.*\.port' $sysdir/cmd_to_run.sh)
 
-            if grep -qE "launch_retroarch\.sh|FullResolution=1" "$dot_port_path"; then
-                # Ports that use RetroArch should always support 560p
-                # for others look for FullResolution=1 in the .port file
-
+            if grep -qE "FullResolution=1" "$dot_port_path"; then
+                # Look for FullResolution=1 in the .port file
                 # set full_resolution_path to a file that will always exist
                 full_resolution_path="/tmp/new_res_available"
             fi
 
         else
             # ----- Everything else ----- #
-            if grep -qF "./retroarch -v" $sysdir/cmd_to_run.sh; then
-                # RetroArch startup launch
-                full_resolution_path="/tmp/new_res_available"
-            else
-                # The rest
-                full_resolution_path=$(grep -o '".*launch\.sh"' $sysdir/cmd_to_run.sh | sed 's/"//g; s/launch\.sh/full_resolution/')
-            fi
+
+            full_resolution_path=$(grep -o '".*launch\.sh"' $sysdir/cmd_to_run.sh | sed 's/"//g; s/launch\.sh/full_resolution/')
         fi
     fi
 
@@ -426,10 +419,10 @@ launch_game() {
             # Change resolution if needed
             if [ -f /tmp/new_res_available ]; then
                 if [ -f "$full_resolution_path" ]; then
-                    log "Screen and program to be launched support 560p"
+                    log "Found full_resolution file, changing resolution to 560p"
                     change_resolution
                 else
-                    log "Screen supports 560p, but program to be launched does not"
+                    log "No full_resolution file found"
                 fi
             else
                 log "Screen does not support 560p"

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -349,7 +349,7 @@ launch_game() {
 
             dot_port_path=$(grep -o '\/mnt\/SDCARD\/Roms\/PORTS.*\.port' $sysdir/cmd_to_run.sh)
 
-            if grep -qE "FullResolution=1" "$dot_port_path"; then
+            if grep -qF "FullResolution=1" "$dot_port_path"; then
                 # Look for FullResolution=1 in the .port file
                 # set full_resolution_path to a file that will always exist
                 full_resolution_path="/tmp/new_res_available"

--- a/static/build/.tmp_update/script/change_resolution.sh
+++ b/static/build/.tmp_update/script/change_resolution.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+res_x=""
+res_y=""
+
+if [ -n "$1" ]; then
+    res_x=$(echo "$1" | cut -d 'x' -f 1)
+    res_y=$(echo "$1" | cut -d 'x' -f 2)
+else
+    res_x=640
+    res_y=480
+fi
+echo "Changing resolution to $res_x x $res_y"
+
+fbset -g "$res_x" "$res_y" "$res_x" "$((res_y * 2))" 32
+
+# inform batmon and keymon of resolution change
+killall -SIGUSR1 batmon
+killall -SIGUSR1 keymon


### PR DESCRIPTION
**RetroArch changes the resolution now itself**

**Improve 560p whitelist to support ports**
Ports using RetroArch are automatically whitelisted
Other ports must include `FullResolution=1` to their .port script

**Fix 560p not working with GLO core overrides**

**fix 560p not working when RetroArch is the startup app**