### PR TITLE
Fixed low battery warning overlapping other battery icons

### DIFF
--- a/src/batmon/batmon.c
+++ b/src/batmon/batmon.c
@@ -127,15 +127,11 @@ int main(int argc, char *argv[])
         if (is_suspended || current_percentage == 500) {
             batteryWarning_hide();
         }
+        else if (current_percentage < warn_at && !config_flag_get(".noBatteryWarning") && !process_isRunning("MainUI")) {
+            batteryWarning_show();
+        }
         else {
-            if (current_percentage < warn_at && !config_flag_get(".noBatteryWarning")) {
-                if (!process_isRunning("MainUI")) {
-                    batteryWarning_show();
-                }
-                else {
-                    batteryWarning_hide();
-                }
-            }
+            batteryWarning_hide();
         }
 #endif
         if (battery_current_state_duration > MAX_DURATION_BEFORE_UPDATE)

--- a/src/batmon/batmon.c
+++ b/src/batmon/batmon.c
@@ -1,5 +1,6 @@
 #include "batmon.h"
 #include "system/device_model.h"
+#include "utils/process.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -127,9 +128,11 @@ int main(int argc, char *argv[])
             batteryWarning_hide();
         else if (current_percentage < warn_at &&
                  !config_flag_get(".noBatteryWarning"))
-            batteryWarning_show();
-        else
-            batteryWarning_hide();
+            if (!process_isRunning("MainUI")) {
+                batteryWarning_show();
+            }
+            else
+                batteryWarning_hide();
 #endif
         if (battery_current_state_duration > MAX_DURATION_BEFORE_UPDATE)
             update_current_duration();

--- a/src/batmon/batmon.c
+++ b/src/batmon/batmon.c
@@ -124,15 +124,19 @@ int main(int argc, char *argv[])
         }
 
 #ifdef PLATFORM_MIYOOMINI
-        if (is_suspended || current_percentage == 500)
+        if (is_suspended || current_percentage == 500) {
             batteryWarning_hide();
-        else if (current_percentage < warn_at &&
-                 !config_flag_get(".noBatteryWarning"))
-            if (!process_isRunning("MainUI")) {
-                batteryWarning_show();
+        }
+        else {
+            if (current_percentage < warn_at && !config_flag_get(".noBatteryWarning")) {
+                if (!process_isRunning("MainUI")) {
+                    batteryWarning_show();
+                }
+                else {
+                    batteryWarning_hide();
+                }
             }
-            else
-                batteryWarning_hide();
+        }
 #endif
         if (battery_current_state_duration > MAX_DURATION_BEFORE_UPDATE)
             update_current_duration();

--- a/src/batmon/batmon.c
+++ b/src/batmon/batmon.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
         if (is_suspended || current_percentage == 500) {
             batteryWarning_hide();
         }
-        else if (current_percentage < warn_at && !config_flag_get(".noBatteryWarning") && !process_isRunning("MainUI")) {
+        else if (current_percentage < warn_at && !warningDisabled()) {
             batteryWarning_show();
         }
         else {
@@ -387,6 +387,8 @@ int batteryPercentage(int value)
 static void *batteryWarning_thread(void *param)
 {
     while (1) {
+        if (temp_flag_get("hasBatteryDisplay"))
+            break;
         display_drawBatteryIcon(0x00FF0000, 15, RENDER_HEIGHT - 30, 10,
                                 0x00FF0000); // draw red battery icon
         usleep(0x4000);
@@ -409,4 +411,9 @@ void batteryWarning_hide(void)
     pthread_cancel(adc_pt);
     pthread_join(adc_pt, NULL);
     adcthread_active = false;
+}
+
+bool warningDisabled(void)
+{
+    return config_flag_get(".noBatteryWarning") || temp_flag_get("hasBatteryDisplay") || process_isRunning("MainUI");
 }

--- a/src/batmon/batmon.h
+++ b/src/batmon/batmon.h
@@ -66,5 +66,6 @@ int batteryPercentage(int);
 static void *batteryWarning_thread(void *param);
 void batteryWarning_show(void);
 void batteryWarning_hide(void);
+bool warningDisabled(void);
 
 #endif // ADC_H__

--- a/src/common/theme/resources.h
+++ b/src/common/theme/resources.h
@@ -6,9 +6,11 @@
 #include <SDL/SDL_ttf.h>
 #include <stdbool.h>
 
-#include "./config.h"
 #include "system/lang.h"
+#include "utils/flags.h"
 #include "utils/log.h"
+
+#include "./config.h"
 
 #define RES_MAX_REQUESTS 200
 
@@ -96,6 +98,15 @@ SDL_Surface *_loadImage(ThemeImages request)
 {
     Theme_s *t = theme();
     int real_location, backup_location;
+
+    if (request == BATTERY_0 ||
+        request == BATTERY_20 ||
+        request == BATTERY_50 ||
+        request == BATTERY_80 ||
+        request == BATTERY_100 ||
+        request == BATTERY_CHARGING) {
+        temp_flag_set("hasBatteryDisplay", true);
+    }
 
     switch (request) {
     case BG_TITLE:
@@ -301,6 +312,8 @@ SDL_Surface *resource_getBrightness(int brightness)
 
 void resources_free()
 {
+    temp_flag_set("hasBatteryDisplay", false);
+
     for (int i = 0; i < images_count; i++)
         if (resources.surfaces[i] != NULL)
             SDL_FreeSurface(resources.surfaces[i]);


### PR DESCRIPTION
This fix disabled the low battery warning when MainUI and other apps with a battery displayed are running