### PR TITLE
Create and enable swap partition on boot.

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -651,9 +651,22 @@ mute_theme_bgm() {
     fi
 }
 
+create_swap() {
+  swapfile="/mnt/SDCARD/cachefile"
+    if [ ! -e "$swapfile" ] ; then
+        log "Creating swap file"
+        dd if=/dev/zero of="$swapfile" bs=1M count=128
+        mkswap "$swapfile"
+    fi
+    log "Enabling swap"
+    swapon "$swapfile"
+}
+
+
 init_system() {
     log "\n:: Init system"
 
+    create_swap
     load_settings
 
     # init_lcd

--- a/static/build/.tmp_update/script/change_resolution.sh
+++ b/static/build/.tmp_update/script/change_resolution.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+sysdir=/mnt/SDCARD/.tmp_update
+logfile=$(basename "$0" .sh)
+. $sysdir/script/log.sh
+
 res_x=""
 res_y=""
 
@@ -10,7 +14,7 @@ else
     res_x=640
     res_y=480
 fi
-echo "Changing resolution to $res_x x $res_y"
+log "Changing resolution to $res_x x $res_y"
 
 fbset -g "$res_x" "$res_y" "$res_x" "$((res_y * 2))" 32
 


### PR DESCRIPTION
Normally, this is done by MainUI, but when we auto-resume a game, MainUI doesn't get a chance to do it.
MainUI checks if the swap exists already, so no double swapon happens.

Fixes #1398 and maybe some other problems that went under the radar..

Negative impact:

If the cachefile exists (which is the norm) only swapon runs, which is near instant.
If the cachefile doesn't exist, it takes a while to generate the file on SD. 
```
(runtime) 1970-01-01 00:00:03: Creating swap file
128+0 records in
128+0 records out
134217728 bytes (128.0MB) copied, 8.452890 seconds, 15.1MB/s
Setting up swapspace version 1, size = 134213632 bytes
UUID=82b7a1fc-188b-4b8c-ba6d-115c440827d1
(runtime) 1970-01-01 00:00:12: Enabling swap
```

But since MainUI then doesn't have to do this, it's not a real negative impact.