### PR TITLE
Remember Net service states across WiFi on/off & Fix GS crash

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -86,7 +86,9 @@ main() {
     HOME=/mnt/SDCARD/RetroArch/
 
     # Disable VNC server flag at boot
-    rm $sysdir/config/.vncServer
+    if [ -f "$sysdir/config/.vncServer" ]; then
+        rm "$sysdir/config/.vncServer"
+    fi
 
     # Detect if MENU button is held
     detectKey 1
@@ -815,7 +817,9 @@ check_networking() {
     if pgrep -f update_networking.sh; then
         log "update_networking already running"
     else
-        rm /tmp/network_changed
+        if [ -f /tmp/network_changed ]; then
+            rm /tmp/network_changed
+        fi
         $sysdir/script/network/update_networking.sh check
     fi
 }

--- a/static/build/.tmp_update/script/network/update_networking.sh
+++ b/static/build/.tmp_update/script/network/update_networking.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 sysdir=/mnt/SDCARD/.tmp_update
 miyoodir=/mnt/SDCARD/miyoo
+confdir=/mnt/SDCARD/.tmp_update/config
+jsonfile="$confdir/.net_service_restart.json"
 filebrowserbin=$sysdir/bin/filebrowser
 filebrowserdb=$sysdir/config/filebrowser/filebrowser.db
 netscript=/mnt/SDCARD/.tmp_update/script/network
@@ -8,10 +10,14 @@ export LD_LIBRARY_PATH="/lib:/config/lib:$miyoodir/lib:$sysdir/lib:$sysdir/lib/p
 export PATH="$sysdir/bin:$PATH"
 is_booting=$([ -f /tmp/is_booting ] && echo 1 || echo 0)
 
+# add service flags here to be remembered when wifi change is detected
+services="httpState ftpState smbdState sshState authsshState authftpState authhttpState"
+
 logfile=$(basename "$0" .sh)
 . $sysdir/script/log.sh
 
 main() {
+    init_json
     set_tzid
     get_password
     case "$1" in
@@ -23,9 +29,11 @@ main() {
             case "$2" in
                 toggle)
                     check_${service}state &
+                    store_state & # if anything is toggled, store the state
                     ;;
                 authed)
                     ${service}_authed &
+                    store_state & 
                     ;;
                 *)
                     print_usage
@@ -47,6 +55,15 @@ main() {
         disableall)
             disable_all_services
             ;;
+        save) # Save the state before wifi goes down so we can quick restore on re-enabling
+            store_state
+            ;;
+        restore) # Restore the net service state after restarting
+            restore_state
+            ;;
+        full_reset) # Do a full reset of the json file
+            full_reset
+            ;;
         *)
             print_usage
             ;;
@@ -59,13 +76,27 @@ check() {
     if wifi_enabled && [ "$is_booting" -eq 1 ]; then
         bootScreen Boot "Waiting for network..."
     fi
+    
+    # Check to see if mainui has demanded wifi go down
+    local current_main_ui_control=$(get_main_ui_control &)
+    local wifi_status=$(wifi_enabled && echo "1" || echo "0")
+
+    if [ "$wifi_status" != "$current_main_ui_control" ]; then
+        update_main_ui_control "$wifi_status" &
+        if [ "$wifi_status" = "1" ]; then
+            # Being turned on, restore the previous state of net servs
+            if [ $is_booting -eq 0 ]; then
+                restore_state
+            fi
+        fi
+    fi
 
     check_wifi
-    check_ftpstate
-    check_sshstate
-    check_telnetstate
-    check_httpstate
-    check_smbdstate
+    check_ftpstate &
+    check_sshstate &
+    check_telnetstate &
+    check_httpstate &
+    check_smbdstate &
 
     if wifi_enabled && flag_enabled ntpWait && [ $is_booting -eq 1 ]; then
         bootScreen Boot "Syncing time..."
@@ -82,6 +113,7 @@ check() {
         touch /tmp/update_checked
         $sysdir/script/ota_update.sh check &
     fi
+
 }
 
 # Function to help disable and kill off all processes
@@ -104,11 +136,14 @@ disable_all_services() {
 
 # Core function
 check_wifi() {
+    # Fixes lockups entering some apps after enabling wifi (because wpa_supp/udhcpc are preloaded with libpadsp.so)
+    libpadspblocker &
+    
     if is_running hostapd; then
         return
     else
         if wifi_enabled; then
-            if ! ifconfig wlan0 || [ -f /tmp/restart_wifi ]; then
+            if ! ifconfig wlan0 >> /dev/null 2>&1 || [ -f /tmp/restart_wifi ]; then
                 if [ -f /tmp/restart_wifi ]; then
                     pkill -9 wpa_supplicant
                     pkill -9 udhcpc
@@ -120,6 +155,7 @@ check_wifi() {
                 ifconfig wlan0 up
                 $miyoodir/app/wpa_supplicant -B -D nl80211 -iwlan0 -c /appconfigs/wpa_supplicant.conf
                 udhcpc -i wlan0 -s /etc/init.d/udhcpc.script &
+                iw dev wlan0 set power_save off
             fi
         else
             if [ ! -f "/tmp/dont_restart_wifi" ]; then
@@ -413,7 +449,6 @@ check_hotspotstate() {
 # This is the fallback!
 # We need to check if NTP is enabled and then check the state of tzselect in /.tmp_update/config/tzselect, based on the value we'll pass the TZ via the env var to ntpd and get the time (has to be POSIX)
 # This will work but it will not export the TZ var across all opens shells so you may find the hwclock (and clock app, retroarch time etc) are correct but terminal time is not.
-# It does set TZ on the tty that Main is running in so this is ok
 
 check_ntpstate() {
     ret_val=0
@@ -533,6 +568,93 @@ get_time() { # handles 2 types of network time, instant from an API or longer fr
 
 # Utility functions
 
+# create/pop the json file for remembering states
+init_json() {
+    if [ ! -f "$jsonfile" ]; then
+        echo '{}' > "$jsonfile"
+    fi
+
+    if [ ! -s "$jsonfile" ]; then
+        echo '{}' > "$jsonfile"
+    fi
+
+    if ! grep -q '"main_ui_control":' "$jsonfile"; then
+        sed -i 's/}$/,"main_ui_control": "0"}/' "$jsonfile"
+    fi
+}
+
+# unhook libpadsp.so on the wifi servs
+libpadspblocker() { 
+    wpa_pid=$(ps -e | grep "[w]pa_supplicant" | awk 'NR==1{print $1}')
+    udhcpc_pid=$(ps -e | grep "[u]dhcpc" | awk 'NR==1{print $1}')
+    if [ -n "$wpa_pid" ] && [ -n "$udhcpc_pid" ]; then
+        if grep -q "libpadsp.so" /proc/$wpa_pid/maps || grep -q "libpadsp.so" /proc/$udhcpc_pid/maps; then
+            echo "Network Checker: $wpa_pid(WPA) and $udhcpc_pid(UDHCPC) found preloaded with libpadsp.so"
+            unset LD_PRELOAD
+            killall -9 wpa_supplicant
+            killall -9 udhcpc 
+            $miyoodir/app/wpa_supplicant -B -D nl80211 -iwlan0 -c /appconfigs/wpa_supplicant.conf & 
+            udhcpc -i wlan0 -s /etc/init.d/udhcpc.script &
+            echo "Network Checker: Removing libpadsp.so preload on wpa_supp/udhcpc"
+        fi
+    fi
+}
+
+# Store the network service state currently
+store_state() {
+    # Make sure main_ui_control gets set at the start
+    local main_ui_control=$(get_main_ui_control)
+    local json_content="{\"main_ui_control\": \"$main_ui_control\""
+
+    for service in $services; do
+        if [ -f "$sysdir/config/.$service" ]; then
+            json_content="$json_content, \"$service\": \"1\""
+        elif [ -f "$sysdir/config/.$service_" ]; then
+            json_content="$json_content, \"$service\": \"0\""
+        fi
+    done
+    
+    # Echo the changes in, jq is too slow for this
+    json_content="$json_content }"
+    echo "$json_content" > "$jsonfile"
+}
+
+# Restore the network service state, don't use jq it's too slow and holds the UI thread until it returns 
+# (you can't background this, you'll miss the checks for net servs as the flags won't be set)
+restore_state() {
+    [ ! -f "$jsonfile" ] && return
+    log "Network Checker: Restoring state from $jsonfile"
+
+    grep -E '"(httpState|ftpState|smbdState|sshState|authsshState|authftpState|authhttpState)":\s*"[01]"' "$jsonfile" | while IFS=":" read -r key value; do
+        key=$(echo "$key" | tr -d ' "{}')
+        value=$(echo "$value" | tr -d ' ",')
+        
+        if echo "$services" | grep -wq "$key"; then
+            if [ "$value" = "1" ]; then
+                enable_flag "$key"
+            elif [ "$value" = "0" ]; then
+                disable_flag "$key"
+            fi
+        fi
+    done
+}
+
+full_reset() {
+    for service in $services; do
+        disable_flag "$service"
+    done
+    rm -f "$jsonfile"
+}
+
+update_main_ui_control() {
+    control_status="$1"
+    jq --arg control_status "$control_status" '.main_ui_control = $control_status' "$jsonfile" > "$jsonfile.tmp" && mv "$jsonfile.tmp" "$jsonfile"
+}
+
+get_main_ui_control() {
+    jq -r '.main_ui_control // "0"' "$jsonfile"
+}
+
 convert_seconds_to_utc_offset() {
     seconds=$(($1))
     if [ $seconds -ne 0 ]; then
@@ -565,7 +687,12 @@ is_noauth_enabled() { # Used to check authMethod val for HTTPFS
 }
 
 print_usage() {
-    echo "Usage: $0 {check|ftp|telnet|http|ssh|ntp|hotspot|smbd|disableall} {toggle|authed} - {ntp|hotspot|telnet} only accept toggle."
+    echo "Usage: $0 {check|ftp|telnet|http|ssh|smbd|disableall|save|restore|full_reset} [toggle|authed]"
+    echo "       - For {ftp|telnet|http|ssh|smbd}, [toggle|authed] can be specified."
+    echo "       - Commands {ntp|hotspot} only accept 'toggle'."
+    echo "       - Commands {save|restore|full_reset} do not require additional args."
+    echo "e.g:"
+    echo "ftp toggle       - Will toggle the current FTP state"
     exit 1
 }
 


### PR DESCRIPTION
## Overview

## Addresses: 
- #1282, 
- #1283, 
- #845

## Adds:
Remembers the state of 4 services and their auth states:

`services="httpState ftpState smbdState sshState authsshState authftpState authhttpState"`

Stores states to a json when anything is changed in tweaks, restores when a change in wifi status (within system.json) is detected. Services are restored at next state change (load GS/Search etc) as per current `runtime.sh`

Not much `jq` is used as it's far too slow in a thread that can block UI loading. 

## Important to note
- check_x functions for net servs are now backgrounded, which can claw back some performance across state/app changes where services start or exit (i can't see or remember any reason not to background these?)
- Adding a check to unhook libpadsp.so from "blocking" processes (wifi) to fix blackscreens comes at a small cost (a delay) entering apps that would otherwise blackscreen

## Flow for both changes

- Enable Wifi
- Enable some net servs in tweaks
- Check servs
- Disable Wifi
- Load gameswitcher/search 
- Check `ps` (to make sure they exited OK)
- Enable Wifi
- Load gameswitcher (This would now black screen, but is fixed by `libpadspblocker`) 
- Back out to MainUI
- Check servs

