### PR TITLE
Add tree and pippi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ src/**/axp
 !axp/
 src/**/batteryMonitorUI
 !batteryMonitorUI/
+src/**/tree
+!tree/
+src/**/pippi
+!pippi/

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,8 @@ core: $(CACHE)/.setup
 	@cd $(SRC_DIR)/pngScale && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/libgamename && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/gameNameList && BUILD_DIR=$(BIN_DIR) make
+	@cd $(SRC_DIR)/tree && BUILD_DIR=$(BIN_DIR) make
+	@cd $(SRC_DIR)/pippi && BUILD_DIR=$(BIN_DIR) make
 # Build dependencies for installer
 	@mkdir -p $(INSTALLER_DIR)/bin
 	@cd $(SRC_DIR)/installUI && BUILD_DIR=$(INSTALLER_DIR)/bin/ VERSION=$(VERSION) make

--- a/src/pippi/Makefile
+++ b/src/pippi/Makefile
@@ -1,0 +1,8 @@
+include ../common/config.mk
+
+TARGET = pippi
+CFLAGS := $(CFLAGS)
+LDFLAGS := $(LDFLAGS)
+
+include ../common/commands.mk
+include ../common/recipes.mk

--- a/src/pippi/pippi.c
+++ b/src/pippi/pippi.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <string.h>
+#include <utils/hash.h>
+
+//
+//  Takes data from stdin and hashes it using the FNV1A_Pippip_Yurii algorithm
+//
+int main()
+{
+    size_t buffer_size = 1024;
+    char *input_buffer = malloc(buffer_size);
+
+    if (input_buffer == NULL) {
+        fprintf(stderr, "Memory allocation error\n");
+        return 1;
+    }
+
+    size_t total_size = 0;
+    size_t bytesRead;
+
+    // Read input from stdin until EOF
+    while ((bytesRead = fread(input_buffer + total_size, 1,
+                              buffer_size - total_size, stdin)) > 0) {
+        total_size += bytesRead;
+
+        // Check if the buffer is full, resize it if needed
+        if (total_size == buffer_size) {
+            buffer_size *= 2;
+            input_buffer = realloc(input_buffer, buffer_size);
+
+            if (input_buffer == NULL) {
+                fprintf(stderr, "Memory reallocation error\n");
+                free(input_buffer);
+                return 1;
+            }
+        }
+    }
+
+    input_buffer[total_size] = '\0';
+
+    int hash = FNV1A_Pippip_Yurii(input_buffer, strlen(input_buffer));
+    printf("%u\n", hash);
+
+    free(input_buffer);
+    return 0;
+}

--- a/src/tree/Makefile
+++ b/src/tree/Makefile
@@ -1,0 +1,8 @@
+include ../common/config.mk
+
+TARGET = tree
+CFLAGS := $(CFLAGS)
+LDFLAGS := $(LDFLAGS)
+
+include ../common/commands.mk
+include ../common/recipes.mk

--- a/src/tree/tree.c
+++ b/src/tree/tree.c
@@ -94,7 +94,7 @@ int tree(const char *directory, const char *prefix, counter_t *counter,
     counter->dirs++;
 
     while ((file_dirent = readdir(dir_handle)) != NULL) {
-        if (file_dirent->d_name[0] == '.') // no hidden files, . or  ..
+        if (strcmp(file_dirent->d_name, ".") == 0 || strcmp(file_dirent->d_name, "..") == 0) // no . or ..
             continue;
 
         if (file_dirent->d_type == DT_DIR &&

--- a/src/tree/tree.c
+++ b/src/tree/tree.c
@@ -1,0 +1,248 @@
+/*  The MIT License (MIT)
+*   
+*   Copyright (c) 2016-present Kevin Newton
+*   
+*   Permission is hereby granted, free of charge, to any person obtaining a copy
+*   of this software and associated documentation files (the "Software"), to deal
+*   in the Software without restriction, including without limitation the rights
+*   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*   copies of the Software, and to permit persons to whom the Software is
+*   furnished to do so, subject to the following conditions:
+*   
+*   The above copyright notice and this permission notice shall be included in
+*   all copies or substantial portions of the Software.
+*   
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+*   THE SOFTWARE.
+*/
+
+// taken from https://github.com/kddnewton/tree/blob/main/tree.c and modified to fit our needs
+
+#define _GNU_SOURCE
+
+#include <dirent.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct counter {
+    size_t dirs;
+    size_t files;
+} counter_t;
+
+typedef struct entry {
+    char *name;
+    int is_dir;
+    struct entry *next;
+} entry_t;
+
+bool is_extension_included(const char *filename,
+                           const char *included_extensions[])
+{
+    if (!included_extensions) // No included extensions specified
+        return true;
+
+    const char *extension = strrchr(filename, '.');
+    if (!extension)
+        return false; // File without extension, exclude
+
+    extension++; // Move past the dot
+    for (int i = 0; included_extensions[i] != NULL; i++)
+        if (strcmp(extension, included_extensions[i]) == 0)
+            return true; // Included extension found
+
+    return false; // No included extension found
+}
+
+int is_directory_excluded(const char *directory_name,
+                          const char *excluded_directories[])
+{
+    if (!excluded_directories) // No excluded directories specified
+        return false;
+
+    for (int i = 0; excluded_directories[i] != NULL; i++)
+        if (strcmp(directory_name, excluded_directories[i]) == 0)
+            return true; // Excluded directory found
+
+    return false;
+}
+
+int tree(const char *directory, const char *prefix, counter_t *counter,
+         const char *included_extensions[],
+         const char *excluded_directories[])
+{
+    entry_t *head = NULL, *current, *iter;
+    size_t size = 0, index;
+
+    struct dirent *file_dirent;
+    DIR *dir_handle;
+
+    char *full_path, *segment, *pointer, *next_prefix;
+
+    dir_handle = opendir(directory);
+    if (!dir_handle) {
+        fprintf(stderr, "Cannot open directory \"%s\"\n", directory);
+        return -1;
+    }
+
+    counter->dirs++;
+
+    while ((file_dirent = readdir(dir_handle)) != NULL) {
+        if (file_dirent->d_name[0] == '.') // no hidden files, . or  ..
+            continue;
+
+        if (file_dirent->d_type == DT_DIR &&
+            is_directory_excluded(file_dirent->d_name, excluded_directories))
+            continue;
+
+        if (file_dirent->d_type == DT_REG &&
+            !is_extension_included(file_dirent->d_name, included_extensions))
+            continue;
+
+        current = malloc(sizeof(entry_t));
+        current->name =
+            strcpy(malloc(strlen(file_dirent->d_name) + 1), file_dirent->d_name);
+        current->is_dir = file_dirent->d_type == DT_DIR;
+        current->next = NULL;
+
+        if (head == NULL) {
+            head = current;
+        }
+        else if (strcmp(current->name, head->name) < 0) {
+            current->next = head;
+            head = current;
+        }
+        else {
+            for (iter = head;
+                 iter->next && strcmp(current->name, iter->next->name) > 0;
+                 iter = iter->next)
+                ;
+
+            current->next = iter->next;
+            iter->next = current;
+        }
+
+        size++;
+    }
+
+    closedir(dir_handle);
+
+    if (!head) { // no entries at all
+        free(head);
+        return 0;
+    }
+
+    // print list
+    for (index = 0; index < size; index++) {
+        if (index == size - 1) {
+            pointer = "└── ";
+            segment = "    ";
+        }
+        else {
+            pointer = "├── ";
+            segment = "│   ";
+        }
+
+        printf("%s%s%s\n", prefix, pointer, head->name);
+
+        if (head->is_dir) {
+            full_path = malloc(strlen(directory) + strlen(head->name) + 2);
+            sprintf(full_path, "%s/%s", directory, head->name);
+
+            next_prefix = malloc(strlen(prefix) + strlen(segment) + 1);
+            sprintf(next_prefix, "%s%s", prefix, segment);
+
+            tree(full_path, next_prefix, counter, included_extensions,
+                 excluded_directories);
+            free(full_path);
+            free(next_prefix);
+        }
+        else {
+            counter->files++;
+        }
+
+        current = head;
+        head = head->next;
+
+        free(current->name);
+        free(current);
+    }
+
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        fprintf(
+            stderr,
+            "Usage: %s <directory> [-e \"directory_name1 directory_name2 ...\"] "
+            "[-i \"ext1 ext2 ...\"]\n",
+            argv[0]);
+        return 1;
+    }
+
+    char *directory = argv[1];
+    printf("%s\n", directory);
+
+    counter_t counter = {0, 0};
+    const char **excluded_directories = NULL;
+    const char **included_extensions = NULL;
+
+    for (int i = 2; i < argc; i++) {
+        if (strcmp(argv[i], "-e") == 0) {
+            if (i + 1 < argc) {
+                char *directories = argv[++i];
+                char *token = strtok(directories, " ");
+                int count = 0;
+                while (token != NULL) {
+                    excluded_directories =
+                        realloc(excluded_directories, (count + 2) * sizeof(char *));
+                    excluded_directories[count++] = token;
+                    excluded_directories[count] = NULL;
+                    token = strtok(NULL, " ");
+                }
+            }
+            else {
+                fprintf(stderr, "Error: Missing argument for -e\n");
+                return 1;
+            }
+        }
+        else if (strcmp(argv[i], "-i") == 0) {
+            if (i + 1 < argc) {
+                char *extensions = argv[++i];
+                char *token = strtok(extensions, " ");
+                int count = 0;
+                while (token != NULL) {
+                    included_extensions =
+                        realloc(included_extensions, (count + 2) * sizeof(char *));
+                    included_extensions[count++] = token;
+                    included_extensions[count] = NULL;
+                    token = strtok(NULL, " ");
+                }
+            }
+            else {
+                fprintf(stderr, "Error: Missing argument for -i\n");
+                return 1;
+            }
+        }
+    }
+
+    tree(directory, "", &counter, included_extensions, excluded_directories);
+
+    printf("\n%zu directories, %zu files\n", counter.dirs ? counter.dirs - 1 : 0,
+           counter.files);
+
+    if (excluded_directories)
+        free(excluded_directories);
+    if (included_extensions)
+        free(included_extensions);
+
+    return 0;
+}

--- a/static/build/.tmp_update/script/network/update_networking.sh
+++ b/static/build/.tmp_update/script/network/update_networking.sh
@@ -230,6 +230,7 @@ check_sshstate() {
             fi
         else
             if wifi_enabled; then
+                mkdir -p $sysdir/etc/dropbear
                 sync
                 if flag_enabled authsshState; then
                     ssh_authed

--- a/static/build/.tmp_update/script/network/update_networking.sh
+++ b/static/build/.tmp_update/script/network/update_networking.sh
@@ -230,7 +230,6 @@ check_sshstate() {
             fi
         else
             if wifi_enabled; then
-                mkdir -p $sysdir/etc/dropbear
                 sync
                 if flag_enabled authsshState; then
                     ssh_authed


### PR DESCRIPTION
Add `tree` command, that can take in optional arguments to exclude directories or to include extensions.

`Usage: %s <directory> [-e "directory_name1 directory_name2 ..."] [-i "ext1 ext2 ..."]`
e.g.
`tree /mnt/SDCARD/Roms/GB/ -e Imgs -i "7z zip gb"`

Add `pippi` command, takes in data from stdin and prints it's FNV1A_Pippip_Yurii hash to stdout
```
/ # echo "Hello World" | pippi
4046137546

/ # cat /mnt/SDCARD/.tmp_update/runtime.sh | pippi
1734444258
/ #
```
