### PR TITLE
Fix discrepancy between MainUI and Onion volume

### DIFF
--- a/src/common/theme/sound.h
+++ b/src/common/theme/sound.h
@@ -17,7 +17,7 @@ void sound_change(void)
         return;
 
     if (!_volume_updated) {
-        int volume = (settings.bgm_volume << 7) / 20;
+        int volume = (settings.bgm_volume * 128) / 20;
         printf_debug("Volume set: %d = %d\n", settings.bgm_volume, volume);
         Mix_Volume(-1, volume);
         _volume_updated = true;

--- a/src/common/theme/sound.h
+++ b/src/common/theme/sound.h
@@ -17,9 +17,7 @@ void sound_change(void)
         return;
 
     if (!_volume_updated) {
-        int volume = settings.bgm_volume > 0
-                         ? 42.3936 * log(1.0239 * (double)settings.bgm_volume)
-                         : 0;
+        int volume = (settings.bgm_volume << 7) / 20;
         printf_debug("Volume set: %d = %d\n", settings.bgm_volume, volume);
         Mix_Volume(-1, volume);
         _volume_updated = true;


### PR DESCRIPTION
Use the same algorithm to calculate the volume as MainUI

`(x << 7) / 20` is equivalent to `(x * 128) / 20` which is just plain linear scaling

Comparison:
![image](https://github.com/OnionUI/Onion/assets/6023076/8c76b872-5ef8-4b62-aaf4-094f69641bb3)


Fixes #1046 