### PR TITLE
Hide low battery status during screenshot

### DIFF
--- a/src/batmon/batmon.c
+++ b/src/batmon/batmon.c
@@ -389,8 +389,10 @@ static void *batteryWarning_thread(void *param)
     while (1) {
         if (temp_flag_get("hasBatteryDisplay"))
             break;
-        display_drawBatteryIcon(0x00FF0000, 15, RENDER_HEIGHT - 30, 10,
-                                0x00FF0000); // draw red battery icon
+        if (display_getBrightnessRaw() != 0) {
+            display_drawBatteryIcon(0x00FF0000, 15, RENDER_HEIGHT - 30, 10,
+                                    0x00FF0000); // draw red battery icon
+        }
         usleep(0x4000);
     }
     return 0;

--- a/src/common/system/display.h
+++ b/src/common/system/display.h
@@ -145,6 +145,17 @@ void display_setScreen(bool enabled)
 
 void display_toggle(void) { display_setScreen(!display_enabled); }
 
+uint32_t display_getBrightnessRaw()
+{
+    uint32_t duty_cycle = 0;
+    FILE *fp;
+
+    if (exists(PWM_DIR "pwm0/duty_cycle")) {
+        file_get(fp, PWM_DIR "pwm0/duty_cycle", "%u", &duty_cycle);
+    }
+    return duty_cycle;
+}
+
 //
 //    Set Brightness (Raw)
 //

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -11,6 +11,8 @@
 #include <unistd.h>
 
 #include "system/axp.h"
+#include "utils/msleep.h"
+#include "system/display.h"
 #include "system/battery.h"
 #include "system/device_model.h"
 #include "system/keymap_hw.h"
@@ -55,6 +57,8 @@ void takeScreenshot(void)
 {
     super_short_pulse();
     display_setBrightnessRaw(0);
+    display_reset();
+    msleep(10);
     osd_hideBar();
     screenshot_recent();
     settings_setBrightness(settings.brightness, true, false);


### PR DESCRIPTION
This commit fixes a small bug where, if the user took a screenshot with low battery, the low battery icon would be showing in the screenshot.

To fix this, we do the following:

- We have the low battery thread check the raw display value and only draw if the raw value is not zero
- During the screenshot action, we reset the display to flush the battery icon out
- We wait a little bit to ensure our display is fresh before screenshotting

Since the display rawValue gets reset once the screenshot ends, the icon returns after the screenshot is done.


Issue describing the bug found here: https://github.com/OnionUI/Onion/issues/1504