### PR TITLE
Add configurable clock overlay for MainUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ src/**/axp
 !axp/
 src/**/batteryMonitorUI
 !batteryMonitorUI/
+src/**/libmainuihooks.so

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,9 @@ core: $(CACHE)/.setup
 	@cd $(SRC_DIR)/pngScale && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/libgamename && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/gameNameList && BUILD_DIR=$(BIN_DIR) make
+# these need to be rebuilt with -fPIC
+	@rm -f $(ROOT_DIR)/include/cjson/cJSON.o
+	@rm -f $(SRC_DIR)/common/utils/*.o
 	@cd $(SRC_DIR)/libmainuihooks && BUILD_DIR=$(LIB_DIR) make
 # Build dependencies for installer
 	@mkdir -p $(INSTALLER_DIR)/bin

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ core: $(CACHE)/.setup
 	@cd $(SRC_DIR)/pngScale && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/libgamename && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/gameNameList && BUILD_DIR=$(BIN_DIR) make
+	@cd $(SRC_DIR)/libmainuihooks && BUILD_DIR=$(LIB_DIR) make
 # Build dependencies for installer
 	@mkdir -p $(INSTALLER_DIR)/bin
 	@cd $(SRC_DIR)/installUI && BUILD_DIR=$(INSTALLER_DIR)/bin/ VERSION=$(VERSION) make

--- a/src/common/theme/config.h
+++ b/src/common/theme/config.h
@@ -19,6 +19,15 @@ typedef enum TextAlign {
     RIGHT
 } Theme_TextAlign;
 
+typedef struct Theme_Time {
+    int size;
+    SDL_Color color;
+    int X;
+    int Y;
+    bool hidelogo;
+    char font[STR_MAX];
+} Time_s;
+
 typedef struct Theme_BatteryPercentage {
     bool visible;
     char font[STR_MAX];
@@ -61,6 +70,7 @@ typedef struct Theme {
     char description[STR_MAX];
     HideLabels_s hideLabels;
     BatteryPercentage_s batteryPercentage;
+    Time_s time;
     Frame_s frame;
     FontStyle_s title;
     FontStyle_s hint;
@@ -104,6 +114,7 @@ bool theme_applyConfig(Theme_s *config, const char *config_path,
     cJSON *json_root = cJSON_Parse(json_str);
     cJSON *json_batteryPercentage =
         cJSON_GetObjectItem(json_root, "batteryPercentage");
+    cJSON *json_time = cJSON_GetObjectItem(json_root, "time");
     cJSON *json_hideLabels = cJSON_GetObjectItem(json_root, "hideLabels");
     cJSON *json_frame = cJSON_GetObjectItem(json_root, "frame");
     cJSON *json_title = cJSON_GetObjectItem(json_root, "title");
@@ -171,6 +182,23 @@ bool theme_applyConfig(Theme_s *config, const char *config_path,
     }
 
     json_getBool(json_batteryPercentage, "fixed", &config->batteryPercentage.fixed);
+
+    // Time overlay theme settings
+
+    json_getBool(json_time, "hidelogo", &config->time.hidelogo);
+    
+    if (!json_getString(json_time, "font", config->time.font) && use_fallbacks)
+        strcpy(config->time.font, config->hint.font);
+
+    json_getInt(json_time, "size", &config->time.size);
+
+    if (!json_color(json_time, "color", &config->time.color) && use_fallbacks)
+        config->time.color = config->hint.color;
+
+    json_getInt(json_time, "X", &config->time.X);
+    json_getInt(json_time, "Y", &config->time.Y);
+
+    // Time overlay theme settings end
 
     json_getInt(json_frame, "border-left", &config->frame.border_left);
     json_getInt(json_frame, "border-right", &config->frame.border_right);

--- a/src/common/utils/file.c
+++ b/src/common/utils/file.c
@@ -474,3 +474,11 @@ void file_add_line_to_beginning(const char *filename, const char *lineToAdd)
     }
     print_debug("Line added to the beginning of the file successfully.\n");
 }
+
+long file_get_size(char *filename)
+{
+    struct stat file_status;
+    if (stat(filename, &file_status) < 0)
+        return -1;
+    return file_status.st_size;
+}

--- a/src/common/utils/file.h
+++ b/src/common/utils/file.h
@@ -110,4 +110,6 @@ void file_delete_line(const char *fileName, int n);
 
 void file_add_line_to_beginning(const char *filename, const char *lineToAdd);
 
+long file_get_size(char *filename);
+
 #endif // UTILS_FILE_H__

--- a/src/libmainuihooks/Makefile
+++ b/src/libmainuihooks/Makefile
@@ -1,0 +1,9 @@
+INCLUDE_UTILS = 0
+include ../common/config.mk
+
+TARGET = libmainuihooks.so
+CFLAGS := $(CFLAGS) -fpic
+LDFLAGS := $(LDFLAGS) -shared -ldl -lSDL -lSDL_ttf
+
+include ../common/commands.mk
+include ../common/recipes.mk

--- a/src/libmainuihooks/Makefile
+++ b/src/libmainuihooks/Makefile
@@ -1,4 +1,4 @@
-INCLUDE_UTILS = 0
+INCLUDE_CJSON=1
 include ../common/config.mk
 
 TARGET = libmainuihooks.so

--- a/src/libmainuihooks/mainuihooks.c
+++ b/src/libmainuihooks/mainuihooks.c
@@ -1,0 +1,146 @@
+#define _GNU_SOURCE
+#include <SDL/SDL.h>
+#include <SDL/SDL_rotozoom.h>
+#include <SDL/SDL_ttf.h>
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <time.h>
+#include <unistd.h>
+
+#define LOGGING_FILE "/mnt/SDCARD/.tmp_update/config/.logging"
+#define GET_TIME_SCRIPT "/mnt/SDCARD/.tmp_update/script/get_time.sh"
+#define TIME_FONT_FILE "/customer/app/Exo-2-Bold-Italic.ttf"
+#define DEFAULT_PRELOAD "/mnt/SDCARD/miyoo/lib/libpadsp.so"
+
+typedef int (*SDL_Flip_ptr)(SDL_Surface *screen);
+SDL_Flip_ptr original_SDL_Flip = NULL;
+typedef int (*printf_ptr)(const char *format, ...);
+printf_ptr original_printf = NULL;
+
+SDL_Surface *clock_surface = NULL;
+TTF_Font *font = NULL;
+SDL_Color white = {255, 255, 255};
+
+bool mainUI_initialized = false;
+bool logging = false;
+
+char *getTime()
+{
+    //TODO: 12/24h?
+    FILE *fp;
+    char output[6];
+
+    fp = popen(GET_TIME_SCRIPT, "r");
+    if (fp == NULL) {
+        fprintf(stderr, "Failed to run get_time.sh\n");
+        return NULL;
+    }
+
+    if (fgets(output, sizeof(output), fp) == NULL) {
+        fprintf(stderr, "Failed to read get_time.sh output\n");
+        pclose(fp);
+        return NULL;
+    }
+
+    pclose(fp);
+
+    char *newline = strchr(output, '\n');
+    if (newline != NULL)
+        *newline = '\0';
+
+    return strdup(output);
+}
+
+//
+// rotate a 32bpp surface's pixels by 180 degrees without allocating new memory
+// only works correctly for surfaces of even height
+//
+void RotateSurface(SDL_Surface *surface)
+{
+    if (!surface || surface->format->BytesPerPixel != 4)
+        return;
+
+    int width = surface->w;
+    int height = surface->h;
+    uint32_t *pixels = (uint32_t *)surface->pixels;
+
+    for (int y = 0; y < height / 2; y++) {
+        for (int x = 0; x < width; x++) {
+            uint32_t topPixel = pixels[y * width + x];
+            uint32_t bottomPixel = pixels[(height - y - 1) * width + (width - x - 1)];
+            pixels[y * width + x] = bottomPixel;
+            pixels[(height - y - 1) * width + (width - x - 1)] = topPixel;
+        }
+    }
+}
+
+int printf(const char *format, ...)
+{
+
+    if (!mainUI_initialized && strcmp(format, "%d run windows\n") == 0)
+        mainUI_initialized = true;
+
+    if (!logging)
+        return 0; // don't waste time printing stuff no one will see
+
+    va_list args;
+    va_start(args, format);
+    int res = vprintf(format, args);
+    va_end(args);
+
+    return res;
+}
+
+int SDL_Flip(SDL_Surface *screen)
+{
+    if (!original_SDL_Flip) // we fucked up
+        return -1;
+    else if (!mainUI_initialized || !font)
+        return original_SDL_Flip(screen);
+
+    char *time_string = getTime();
+    clock_surface = TTF_RenderUTF8_Blended(font, time_string, white);
+    free(time_string);
+    RotateSurface(clock_surface);
+
+    // TODO: coords from theme config?
+    SDL_Rect dest = {160, 467 - (clock_surface->h), 0, 0};
+
+    SDL_BlitSurface(clock_surface, NULL, screen, &dest);
+    return original_SDL_Flip(screen);
+}
+
+void __attribute__((constructor)) load(void)
+{
+    puts(":: Hi from mainuihooks");
+
+    // remove this .so from preload for child processes
+    setenv("LD_PRELOAD", DEFAULT_PRELOAD, 1);
+
+    // get pointers to original functions
+    original_printf = dlsym(RTLD_NEXT, "printf");
+    original_SDL_Flip = dlsym(RTLD_NEXT, "SDL_Flip");
+
+    // check if logging is enabled
+    if (access(LOGGING_FILE, F_OK) == 0)
+        logging = true;
+
+    // load font
+    TTF_Init();
+
+    // TODO: font size from theme config?
+    font = TTF_OpenFont(TIME_FONT_FILE, 24);
+    if (!font)
+        printf("TTF_OpenFont: %s\n", TTF_GetError());
+}
+
+void __attribute__((destructor)) unload(void)
+{
+    if (font)
+        TTF_CloseFont(font);
+    if (clock_surface)
+        SDL_FreeSurface(clock_surface);
+    TTF_Quit();
+
+    puts(":: Bye from mainuihooks");
+}

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -190,10 +190,34 @@ check_main_ui() {
     fi
 }
 
+toggle_topbar() {
+    theme_path="$(/customer/app/jsonval theme)"
+    config_path="${theme_path%/}/config.json"
+    regular_path="${theme_path%/}/skin/miyoo-topbar.png"
+    hidden_path="${theme_path%/}/skin/miyoo-topbar-hidden.png"
+    invis_path=/mnt/SDCARD/.tmp_update/res/miyoo-topbar-invis.png
+    hide_logo=$(sed -n 's/.*"hidelogo": \([^,}]*\).*/\1/p' "$config_path")
+
+    if [ $hide_logo == "true" ]; then
+        if  [ ! $(xcrc "$regular_path") == $(xcrc "$invis_path") ]; then
+            cp -f "$regular_path" "$hidden_path"
+            cp -f "$invis_path" "$regular_path"
+        fi
+    else
+        if [ -f "$hidden_path" ] && [ $(xcrc "$regular_path") == $(xcrc "$invis_path") ]; then
+            cp -f "$hidden_path" "$regular_path"
+        fi
+    fi
+    sync
+}
+
 launch_main_ui() {
     log "\n:: Launch MainUI"
 
     cd $sysdir
+    
+    # hide or unhide miyoo-topbar
+    toggle_topbar
 
     # Generate battery percentage image
     mainUiBatPerc

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -215,8 +215,8 @@ launch_main_ui() {
     cd $miyoodir/app
     PATH="$miyoodir/app:$PATH" \
         LD_LIBRARY_PATH="$miyoodir/lib:/config/lib:/lib" \
-        LD_PRELOAD="$miyoodir/lib/libpadsp.so" \
-        ./MainUI 2>&1 > /dev/null
+        LD_PRELOAD="$sysdir/lib/libmainuihooks.so:$miyoodir/lib/libpadsp.so" \
+        ./MainUI
 
     # Merge the last game launched into the recent list
     check_hide_recents

--- a/static/build/.tmp_update/script/get_time.sh
+++ b/static/build/.tmp_update/script/get_time.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+TZ="$(cat "/mnt/SDCARD/.tmp_update/config/.tz")" date +"%H:%M"

--- a/static/build/.tmp_update/script/get_time.sh
+++ b/static/build/.tmp_update/script/get_time.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-TZ="$(cat "/mnt/SDCARD/.tmp_update/config/.tz")" date +"%H:%M"
+[ "$1" = "--12h" ] && FORMAT="+%I:%M %P" || FORMAT="+%H:%M"
+
+TZ="$(cat "/mnt/SDCARD/.tmp_update/config/.tz")" date "$FORMAT"


### PR DESCRIPTION
Add configurable clock overlay for MainUI

Global configuration in tweaks:
* On/off
* 12/24h

Configurable per theme:
* Font
* Font size
* Font color
* Position X Y
* whether to hide miyoo-topbar or not


TODO:

- [ ] Theme overrides
- [ ] Global config in tweaks

![MainUI_009](https://github.com/OnionUI/Onion/assets/6023076/dca80966-aa0c-4fe1-9390-90857ee302db)
