### PR TITLE
PICO-8 Standalone - Mouse/Menu key Improvements and fixes in SDL2 lib

### DIFF
--- a/static/packages/RApp/PICO-8 (PICO-8 standalone)/RApp/PICO-8/cfg/onioncfg.json
+++ b/static/packages/RApp/PICO-8 (PICO-8 standalone)/RApp/PICO-8/cfg/onioncfg.json
@@ -23,7 +23,7 @@
     "maxAcceleration":4.0,
     "incrementModifier":1.0,
     "disableMouseHotkey":0,
-    "disableMouseIcon":1,
+    "disableMouseIcon":0,
     "minx":40,
     "miny":0,
     "maxx":280,

--- a/static/packages/RApp/PICO-8 (PICO-8 standalone)/RApp/PICO-8/cfg/onioncfg.json
+++ b/static/packages/RApp/PICO-8 (PICO-8 standalone)/RApp/PICO-8/cfg/onioncfg.json
@@ -21,7 +21,13 @@
     "acceleration":4.0,
     "accelerationRate":1.5,
     "maxAcceleration":4.0,
-    "incrementModifier":1.0
+    "incrementModifier":1.0,
+    "disableMouseHotkey":0,
+    "disableMouseIcon":1,
+    "minx":40,
+    "miny":0,
+    "maxx":280,
+    "maxy":236
   },
   "performance":{
     "cpuclock":1500,
@@ -30,7 +36,7 @@
     "mincpu":600
   },
   "bezel":{
-    "current_bezel":1,
+    "current_bezel":0,
     "current_integer_bezel":0,
     "bezel_path":"\/mnt\/SDCARD\/RApp\/PICO-8\/res\/bezel\/standard",
     "digit_path":"\/mnt\/SDCARD\/RApp\/PICO-8\/res\/digit",


### PR DESCRIPTION
 Mouse can be tested in this cart (which is also available through splore):
 https://www.lexaloffle.com/bbs/?tid=3467

- Fixes menu button handling so it doesn't exit on "PRESSED" event (fixes being unable to screenshot, change brightness etc) (may take 2 presses)
- Fixes mouse bounds from previous regression in #1425 
- Adds option flags to onioncfg.json to:
    - Hide the mouse icon
    - Set custom mouse bounds in the config (mostly for testing purposes)
    - Remove the mouse hotkey altogether so it can be rebound to something else
    
 These values will default to:
 
 ```c
 #define MMIYOO_DEFAULT_MOUSE_HOTKEY         0
#define MMIYOO_DEFAULT_MOUSE_ICON           0
#define MMIYOO_DEFAULT_MOUSE_MINX           40
#define MMIYOO_DEFAULT_MOUSE_MINY           0
#define MMIYOO_DEFAULT_MOUSE_MAXX           280
#define MMIYOO_DEFAULT_MOUSE_MAXY           236
```
 
 If they do not exist in the json config file. 
 
 Which should look like:

```json
  "mouse":{
    "scaleFactor":1,
    "acceleration":4.0,
    "accelerationRate":1.5,
    "maxAcceleration":4.0,
    "incrementModifier":1.0,
    "disableMouseHotkey":0,
    "disableMouseIcon":1,
    "minx":40,
    "miny":0,
    "maxx":280,
    "maxy":236
  },
  ```
 
 When:
 ```json
     "disableMouseHotkey":1,
```
Is set, L2 can be rebound to a different key with:

```json
  "customkeys":{
    "A":"Z",
    "B":"X",
    "X":"ESCAPE",
    "Y":"D",
    "L1":"D",
    "L2":"D", <<<<<<<<<<
    "R1":"D",
    "R2":"D",
    "LeftDpad":"LEFT",
    "RightDpad":"RIGHT",
    "UpDpad":"UP",
    "DownDpad":"DOWN",
    "Start":"RETURN",
    "Select":"D",
    "Menu":"D"
  },
  ```
 