### PR TITLE
Fix Easy Netplay when starting through Search

### DIFF
--- a/static/build/.tmp_update/script/netplay/easy-netplay_server.sh
+++ b/static/build/.tmp_update/script/netplay/easy-netplay_server.sh
@@ -94,30 +94,33 @@ create_cookie_info() {
 
 # We'll start Retroarch in host mode with -H with the core and rom paths loaded in.
 start_retroarch() {
-	log "RetroArch" "Starting RetroArch..."
-	echo "*****************************************"
-	echo "romfullpath: $cookie_rom_path"
-	echo "platform: ${platform}"
-	echo "netplaycore: $netplaycore"
-	echo "core_config_folder: $core_config_folder"
-	echo "cpuspeed: $cpuspeed"
-	echo "*****************************************"
+    log "RetroArch" "Starting RetroArch..."
+    echo "*****************************************"
+    echo "romfullpath: $cookie_rom_path"
+    echo "platform: ${platform}"
+    echo "netplaycore: $netplaycore"
+    echo "core_config_folder: $core_config_folder"
+    echo "cpuspeed: $cpuspeed"
+    echo "*****************************************"
 
-	# We set core CPU speed for Netplay
-	if [ -n "$cpuspeed" ]; then
-		PreviousCPUspeed=$(cat "/mnt/SDCARD/Saves/CurrentProfile/config/${core_config_folder}/cpuclock.txt")
-		echo -n $cpuspeed >"/mnt/SDCARD/Saves/CurrentProfile/config/${core_config_folder}/cpuclock.txt"
-	fi
+    # Cleanup $cookie_rom_path if it contains "/mnt/SDCARD/Emu/XX(ANYTHINGHERE)/launch.sh:"
+    cookie_rom_path=$(echo "$cookie_rom_path" | sed 's|/mnt/SDCARD/Emu/.*/launch.sh:||')
 
-	cd /mnt/SDCARD/RetroArch
-	# sleep 5
-	HOME=/mnt/SDCARD/RetroArch ./retroarch --appendconfig=./.retroarch/easynetplay_override.cfg -H -L "$netplaycore" "$cookie_rom_path"
-	# We restore previous core CPU speed
-	if [ -n "$PreviousCPUspeed" ]; then
-		echo -n $PreviousCPUspeed >"/mnt/SDCARD/Saves/CurrentProfile/config/${core_config_folder}/cpuclock.txt"
-	else
-		rm -f "/mnt/SDCARD/Saves/CurrentProfile/config/${core_config_folder}/cpuclock.txt"
-	fi
+    # We set core CPU speed for Netplay
+    if [ -n "$cpuspeed" ]; then
+        PreviousCPUspeed=$(cat "/mnt/SDCARD/Saves/CurrentProfile/config/${core_config_folder}/cpuclock.txt")
+        echo -n $cpuspeed > "/mnt/SDCARD/Saves/CurrentProfile/config/${core_config_folder}/cpuclock.txt"
+    fi
+
+    cd /mnt/SDCARD/RetroArch
+    # sleep 5
+    HOME=/mnt/SDCARD/RetroArch ./retroarch --appendconfig=./.retroarch/easynetplay_override.cfg -H -L "$netplaycore" "$cookie_rom_path"
+    # We restore previous core CPU speed
+    if [ -n "$PreviousCPUspeed" ]; then
+        echo -n $PreviousCPUspeed > "/mnt/SDCARD/Saves/CurrentProfile/config/${core_config_folder}/cpuclock.txt"
+    else
+        rm -f "/mnt/SDCARD/Saves/CurrentProfile/config/${core_config_folder}/cpuclock.txt"
+    fi
 }
 
 cleanup() {


### PR DESCRIPTION
EN is failing to launch RetroArch as it retrieves the wrong path from GLO. 

```
[INFO] [Content]: Loading content file: "/mnt/SDCARD/Emu/GB/launch.sh:/mnt/SDCARD/Emu/GB/../../Roms/GB/Balloon Kid (USA, Europe).zip".
[ERROR] [Content]: Could not read content file "/mnt/SDCARD/Emu/GB/launch.sh:/mnt/SDCARD/Emu/GB/../../Roms/GB/Balloon Kid (USA, Europe).zip"
```

This PR will fix the path passed into RetroArch and resolves: #1461 pending validation on review.

To reproduce:
Follow the instructions in the Issue, to reiterate:

- Launch Search, 
- Search for a netplay capable Rom (Balloon kid is a good choice)
- Open GLO
- Open Netplay, start Easy Netplay (Hotspot)
- Observe instant failure

Add script and re-follow instructions, now working.