### PR TITLE
 Add feature to always set specific audio volume upon startup 

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -738,6 +738,16 @@ load_settings() {
             mv -f temp /mnt/SDCARD/system.json
         fi
     fi
+
+    default_volume="${sysdir}/config/.defaultVolume-${device_uuid}"
+    if [ -f "$default_volume" ]; then
+        volume=$(printf '%d' "$(cat "$default_volume")")
+        if [ $? -eq 0 ]; then
+            cat /mnt/SDCARD/system.json |
+                sed 's/^\s*"vol":\s*[0-9][0-9]*/\t"vol":\t'$volume'/g' > temp
+            mv -f temp /mnt/SDCARD/system.json
+        fi
+    fi
 }
 
 save_settings() {


### PR DESCRIPTION
This adds the ability to always set the volume to a specific value during startup. It is enabled by writing the numeric value to `${sysdir}/config/.defaultVolume-${device_uuid}`. 

Ex.
```
$ cat .tmp_update/config/.defaultVolume-C2A037C6B080
7
$ cat .tmp_update/config/.defaultVolume-D7C3FDF55222
0
```

## Why?
I developed this feature to solve different problems with both of my devices:
- **MMv4**: the runtime.sh script currently forces non-plus devices to maximum volume due to the device having an analog adjustment wheel ([see here](https://github.com/OnionUI/Onion/blob/61ff355a525c07dd024b0afcd3bfa7c43239b1ca/static/build/.tmp_update/runtime.sh#L725-L740)). However, this results in my device being _slightly_ audible even when the potentiometer is at its lowest. This is likely an issue with my device's potentiometer, but it otherwise works fine. I previously worked around this by lowering the boost volume after each boot. With this change, a value of `7` allows for complete silence with the wheel turned down and a reasonable volume with the wheel at max.
- **MMP**: I always want the device to startup with a volume of `0` to any surprises of it blasting at full-volume when resuming the game (ex. in bed). 


I've tested and am currently using this modification on both of my devices without issue. That said, the code change could probably be a little cleaner - perhaps living in the already device-specific json files. This feature could then be added to the setting UI.

Thoughts?