### PR TITLE
FIX: Setting Swap L1<>L2 in Drastic breaks Menu Exits

### DIFF
--- a/src/keymon/menuButtonAction.h
+++ b/src/keymon/menuButtonAction.h
@@ -11,6 +11,7 @@
 #include "system/state.h"
 #include "system/system_utils.h"
 #include "utils/apps.h"
+#include "utils/flags.h"
 
 #include "../tweaks/tools_defs.h"
 #include "./input_fd.h"
@@ -103,9 +104,16 @@ bool terminate_drastic(void)
     char fname[20];
 
     if (pid) {
-        system("sendkeys 1 1, 18 1");
-        usleep(200000); // 0.2s
-        system("sendkeys 1 0, 18 0");
+        // If swap L<>L2 is on, the off button combo becomes 1 + 15 instead of 1 + 18
+        if(temp_flag_get("drastic_swap_l1l2")) {
+            system("sendkeys 1 1, 15 1");
+            usleep(200000); // 0.2s
+            system("sendkeys 1 0, 15 0");
+        } else {
+            system("sendkeys 1 1, 18 1");
+            usleep(200000); // 0.2s
+            system("sendkeys 1 0, 18 0");
+        };
 
         sprintf(fname, "/proc/%d", pid);
         uint32_t count = 150; // 30s

--- a/static/packages/Emu/Nintendo - DS (Drastic)/Emu/NDS/launch.sh
+++ b/static/packages/Emu/Nintendo - DS (Drastic)/Emu/NDS/launch.sh
@@ -38,6 +38,14 @@ if [ "$CUST_CPUCLOCK" == "1" ]; then
     cpuclock 1500
 fi
 
+l_triggers_swapped=$(jq ".swap_l1l2" "/mnt/SDCARD/Emu/NDS/resources/settings.json")
+
+if [ $l_triggers_swapped -eq 1 ]; then
+    touch /tmp/drastic_swap_l1l2
+else
+    rm -f /tmp/drastic_swap_l1l2
+fi
+
 ./drastic "$1"
 
 sync


### PR DESCRIPTION
## Description
This fixes a bug described below. This is due to the keymon assuming the exit button combo is MENU+L1, which is not the case when we swap L triggers. This commit now checks the JSON first, and swaps the exit button accordingly. 

## Steps to Reproduce
1. Open NDS Game
2. Press MENU + START to open Drastic Settings Menu
3. Scroll down and toggle "Swap L1-L2" to "Yes"
4. Press B to return to Game
5. Press Menu

## Expected Result
- Pressing MENU should exit the game

## Actual Result
- Pressing MENU Loads State
