### PR TITLE
Add basic network diag script

### DIFF
--- a/static/build/.tmp_update/script/diagnostics/util_exporter.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_exporter.sh
@@ -26,6 +26,7 @@ move_runtime_logs() {
 
 exporter() {
     log "Exporting and archiving logs"
+    rm -rf $filename
     move_runtime_logs
     sync
     sleep 1

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -114,7 +114,7 @@ test_download() {
 }
 
 test_dns_resolution() {
-    local dns_test_host="google.com"
+    local dns_test_host="google.co.uk"
     if nslookup "$dns_test_host" > /dev/null 2>&1; then
         log_message "DNS resolution test for $dns_test_host successful. \n"
         return 0
@@ -291,9 +291,6 @@ if [ "$#" -gt 0 ]; then
             ;;
         test_download)
             test_download "$2"
-            ;;
-        test_dns_resolution)
-            test_dns_resolution
             ;;
         check_firmware_for_dns_issue)
             check_firmware_for_dns_issue

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -135,7 +135,6 @@ test_dns_resolution() {
 }
 
 check_firmware_for_dns_issue() {
-    section_header "Firmware DNS Check"
     local version
     version=$(/etc/fw_printenv miyoo_version)
     if [ "$version" = "202303021817" ]; then
@@ -163,7 +162,6 @@ check_retroachievements_api() {
     local api_key="dummy"
     local api_url="https://retroachievements.org/API/API_GetAchievementOfTheWeek.php?z=$username&y=$api_key"
     
-    section_header "RetroAchievements API Check"
     log_message "Checking RetroAchievements API availability"
 
     local status=$(curl -s -o /dev/null -w "%{http_code}" --insecure "$api_url")
@@ -268,7 +266,6 @@ check_network_complete() {
 
 
 display_summary() {
-    section_header "Summary of Network Checks"
     log_message "Ping Test Results: $ping_success successful out of $ping_total attempts."
     log_message "Website Availability: $website_success successful out of $website_total checks."
     log_message "Download Test Results: $download_success successful out of $download_total attempts."
@@ -337,7 +334,7 @@ fi
 main() {
     # initial setup, check wifi, check chip, check driver is inserted
     # check we're connected to a network
-    section_header "Hardware and config checks"
+    section_header_big "Hardware and config checks"
     
     check_usb_devices
 
@@ -378,9 +375,11 @@ main() {
     test_download $PICO_BBS_ASSET
     
     # check cheevosapi status
+    section_header_big "RetroAchievements API Check"
     check_retroachievements_api
     
     # check if the user is running old firmware that does not support DNS
+    section_header_big "Firmware DNS Check"
     check_firmware_for_dns_issue
 
     # pull some interface config and dmesg
@@ -389,6 +388,7 @@ main() {
     pull_common_logs
     
     # summary gen
+    section_header_big "Summary of Network Checks"
     display_summary
 
     sync

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -30,7 +30,7 @@ program=$(basename "$0" .sh)
 
 log_message() {
     local message="$(date +"%Y-%m-%d %H:%M:%S") - $1"
-    echo -e "$message" >> "${LOGDIR}/$LOG_EX_NAME.log"
+    echo -e "$message" >> "${LOGDIR}/$LOG_EX_FILE.log"
     echo -e "$message" # for console
 }
 

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -40,8 +40,8 @@ section_header() {
 }
 
 section_header_big() {
-    local header=$1
-    log_message "================================ $header ================================"
+    local header_big=$1
+    log_message "================================ $header_big ================================"
 }
 
 if [ -f "$LOGDIR/$LOG_EX_FILE.log" ]; then

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -1,0 +1,391 @@
+#!/bin/sh
+
+# This script will run a suite of network checks from the device, the captured data is mostly response codes from services and ping replies
+# It will however pull dmesg, which may contain the users WiFi SSID. Be cautious as to where you ask the user to upload this.
+
+menulabel="Network log snapshot"
+tooltip="Check common websites/services for access \n and export the logs to SD:log_export.7z"
+
+##################
+## SETUP ##
+##################
+SDDIR="/mnt/SDCARD"
+SYSDIR="${SDDIR}/.tmp_update"
+LOGDIR="${SYSDIR}/logs"
+DIAGSDIR="${SYSDIR}/script/diagnostics"
+THEME_TEST_ASSET="https://raw.githubusercontent.com/OnionUI/Themes/main/release/M%20by%20tenlevels.zip"
+PORTS_TEST_ASSET="https://github.com/OnionUI/Ports-Collection/releases/latest/download/Sonic.Mania.7z"
+PICO_BBS_ASSET="https://www.lexaloffle.com/bbs/cpost_lister3.php?cat=7"
+RA_CFG="/mnt/SDCARD/RetroArch/.retroarch/retroarch.cfg"
+RA_URL="https://retroachievements.org"
+
+##################
+## LOGGING FUNCTION ##
+##################
+
+logfile=util_netcheck
+. "${SYSDIR}/script/log.sh"
+program=$(basename "$0" .sh)
+
+log_message() {
+    local message="$(date +"%Y-%m-%d %H:%M:%S") - $1"
+    echo -e "$message" >> "${LOGDIR}/network_check.log"
+    echo -e "$message" # for console
+}
+
+section_header() {
+    local header=$1
+    log_message "======== $header ========"
+}
+
+##################
+## CHECKING      ##
+##################
+
+ping_success=0
+ping_total=0
+website_success=0
+website_total=0
+download_success=0
+download_total=0
+
+##################
+## Util functions ##
+##################
+
+check_usb_devices() {
+    local device_count=$(lsusb | wc -l)
+    device_count=$((device_count))
+
+    if [ "$device_count" -ge 3 ]; then
+        log_message "Check successful: Found $device_count USB devices connected."
+    else
+        log_message "Check failed: Only $device_count USB devices found. Third USB device missing, possible WiFi chip failure - does WiFi work?"
+    fi
+}
+
+perform_ping() {
+    local host=$1
+    local service=$2
+    section_header "Ping Test for $service"
+    log_message "Starting ping test for $service: $host"
+    ping_total=$((ping_total + 1))
+    if ping -c 1 -W 2 $host > /dev/null 2>&1; then
+        log_message "Ping to $host ($service) successful. \n"
+        ping_success=$((ping_success + 1))
+        return 0
+    else
+        log_message "Ping to $host ($service) failed. \n"
+        return 1
+    fi
+}
+
+check_website() {
+    local url=$1
+    website_total=$((website_total + 1))
+    section_header "Website Availability Check"
+    log_message "Checking website availability: $url"
+    if wget -q --no-check-certificate --spider $url; then
+        log_message "Website $url is up.\n"
+        website_success=$((website_success + 1))
+        return 0
+    else
+        log_message "Website $url is down.\n"
+        return 1
+    fi
+}
+
+test_download() {
+    local url=$1
+    download_total=$((download_total + 1))
+    log_message "Testing download from: $url"
+    # check the response trying to download assets from $url
+    # 200 is good, anything else not so good.
+    # doesn't actually download the asset, just attempts
+    local status=$(curl -o /dev/null -s -w "%{http_code}" -L --head --insecure "$url")
+    if [ "$status" -eq 200 ]; then
+        log_message "Download test for $url was successful. Status code: $status \n"
+        download_success=$((download_success + 1))
+        return 0
+    else
+        log_message "Download test for $url failed with status code: $status \n"
+        return 1
+    fi
+}
+
+test_dns_resolution() {
+    local dns_test_host="google.com"
+    if nslookup "$dns_test_host" > /dev/null 2>&1; then
+        log_message "DNS resolution test for $dns_test_host successful. \n"
+        return 0
+    else
+        log_message "DNS resolution test for $dns_test_host failed. \n"
+        return 1
+    fi
+}
+
+check_firmware_for_dns_issue() {
+    section_header "Firmware DNS Check"
+    local version
+    version=$(/etc/fw_printenv miyoo_version)
+    if [ "$version" = "202303021817" ]; then
+        log_message "DNS Failure will occur due to firmware version, update your firmware. \n"
+        return 0
+    else
+        log_message "Firmware supports DNS, testing...\n"
+        test_dns_resolution
+        return 1
+    fi
+}
+
+pull_common_logs() {
+    ifconfig -a >> "${LOGDIR}/network_info.log"
+    dmesg | grep -i eth0 >> "${LOGDIR}/network_info.log"
+    dmesg >> "${LOGDIR}/network_dmesg.log"
+}
+
+check_retroachievements_api() {
+    # we're not actually checking if the API lets us login as we don't know the users API key but
+    # we'll request some info from the API and see if it replies with a code we expect
+    # it should respond as unauthorised/unauthed (401 or 419...) 
+    # we can't use a POST on the login as they use CSRF
+    local username="dummy"
+    local api_key="dummy"
+    local api_url="https://retroachievements.org/API/API_GetAchievementOfTheWeek.php?z=$username&y=$api_key"
+    
+    section_header "RetroAchievements API Check"
+    log_message "Checking RetroAchievements API availability"
+
+    local status=$(curl -s -o /dev/null -w "%{http_code}" --insecure "$api_url")
+
+    case "$status" in
+        200)    # won't ever happen, we're not passing creds - leaving until i figure out a way to do this
+            log_message "API is accessible and credentials are valid. Status code: $status \n"
+            return 0
+            ;;
+        401)    # the one we should get, indicates the API is up and responding to a failed attempt
+            log_message "API check was successful, returned 401 unauthorized. Status code: $status \n"
+            return 0
+            ;;
+        419)    # i doubt we'll get this but catch it anyway (appears on a request to: http://retroachievements.org/API/dorequest.php?r=login)
+            log_message "API check was successful, returned 419 unauthed. Status code: $status \n"
+            return 0
+            ;;
+        503)    # bad
+            log_message "API service is unavailable (503). Check back later. \n"
+            return 1
+            ;;
+        500)    # bad
+            log_message "Internal server error (500). \n"
+            return 1
+            ;;
+        404)    # bad
+            log_message "API endpoint not found (404). \n"
+            return 1
+            ;;
+        408)    # bad
+            log_message "Request timed out (408). \n"
+            return 1
+            ;;
+        0)      # bad
+            log_message "Failed to connect to API. \n"
+            return 1
+            ;;
+        *)      # bad
+            log_message "API check failed with status code: $status \n"
+            return 1
+            ;;
+    esac
+}
+
+check_valid_adaptor() {
+    local active_interfaces=$(ifconfig | awk '/^[a-zA-Z0-9]/ {print $1}' | grep -v 'lo' | tr -d ':')
+
+    if [ -z "$active_interfaces" ]; then
+        log_message "No active network interfaces found."
+        return 1
+    else
+        log_message "Active network interfaces found: $active_interfaces"
+        return 0
+    fi
+}
+
+check_network_complete() {
+    local interface=$(ifconfig | awk '/^[a-zA-Z0-9]/ {print $1}' | grep -v 'lo' | tr -d ':' | head -n 1)
+
+    if [ -z "$interface" ]; then
+        log_message "No network interface found to check."
+        return 1
+    fi
+
+    local ip_address=$(ifconfig $interface | grep 'inet addr:' | awk '{print $2}' | cut -d':' -f2)
+
+    if [ -z "$ip_address" ]; then
+        log_message "$interface does not have an IP address assigned."
+        return 1
+    fi
+
+    local subnet_mask=$(ifconfig $interface | grep 'Mask:' | awk '{print $4}' | cut -d':' -f2)
+
+    if [ -z "$subnet_mask" ]; then
+        log_message "No subnet mask set for $interface."
+        return 1
+    fi
+
+    local gateway=$(route -n | awk '/^0.0.0.0/ {print $2}' | head -n 1)
+
+    if [ -z "$gateway" ]; then
+        log_message "No default gateway set for $interface."
+        return 1
+    fi
+
+    log_message "Network check complete for $interface: IP $ip_address, Subnet Mask $subnet_mask, Gateway $gateway"
+    return 0
+}
+
+display_summary() {
+    section_header "Summary of Network Checks"
+    log_message "Ping Test Results: $ping_success successful out of $ping_total attempts."
+    log_message "Website Availability: $website_success successful out of $website_total checks."
+    log_message "Download Test Results: $download_success successful out of $download_total attempts."
+    
+    # Determine the overall network health based on the ratio of success to total checks
+    if [ "$ping_success" -eq "$ping_total" ]; then
+        log_message "Ping replies from all DNS providers - OK"
+    elif [ "$ping_success" -gt 0 ]; then
+        log_message "Ping replies from DNS providers - Degraded"
+    else
+        log_message "Ping responses from DNS Providers - Failed"
+    fi
+    
+    if [ "$website_success" -eq "$website_total" ]; then
+        log_message "Website checks - All sites are reachable"
+    elif [ "$website_success" -gt 0 ]; then
+        log_message "Website checks - Some sites are unreachable"
+    else
+        log_message "Website checks - All sites are unreachable"
+    fi
+    
+    if [ "$download_success" -eq "$download_total" ]; then
+        log_message "Download tests - All downloads successful"
+    elif [ "$download_success" -gt 0 ]; then
+        log_message "Download tests - Some downloads failed"
+    else
+        log_message "Download tests - All downloads failed"
+    fi
+}
+
+if [ "$#" -gt 0 ]; then
+    if check_valid_adaptor; then
+        log_message "Proceeding, valid adaptor found" 
+    else
+        log_message "Exiting, no valid adaptor found" 
+    fi
+        
+    case "$1" in
+        perform_ping)
+            perform_ping "$2" "$3"
+            ;;
+        check_website)
+            check_website "$2"
+            ;;
+        test_download)
+            test_download "$2"
+            ;;
+        test_dns_resolution)
+            test_dns_resolution
+            ;;
+        check_firmware_for_dns_issue)
+            check_firmware_for_dns_issue
+            ;;
+        check_network_complete)
+            check_network_complete
+            ;;
+        pull_common_logs)
+            pull_common_logs
+            ;;
+        check_retroachievements_api)
+            check_retroachievements_api
+            ;;
+        display_summary)
+            display_summary
+            ;;
+        *)
+            echo "Unsupported function or incorrect usage."
+            echo "Usage: $0 <function> [<args>]"
+            exit 1
+            ;;
+    esac
+    exit
+fi
+
+main() {
+    # initial setup, check wifi, check chip, check driver is inserted
+    # check we're connected to a network
+    section_header "Hardware and config checks"
+    
+    check_usb_devices
+
+    # check wifi, obviously
+    wifi_setting=$(/customer/app/jsonval wifi)
+    if [ "$wifi_setting" -eq 0 ]; then
+        log_message "WiFi is disabled, exiting script to avoid running network-dependent checks."
+        exit 0 # drop out, no logfile will be created
+    else
+        log_message "WiFi is enabled, proceeding with network checks."
+    fi
+    
+    # check our adaptor is valid and if we're on a completely negotiated network
+    if check_valid_adaptor; then
+        check_network_complete # we're connected but do we have the requirements
+    fi
+    
+    # generic pings, lets see who we can hit
+    section_header "Network Ping Tests"
+    perform_ping "8.8.8.8" "Google DNS"
+    perform_ping "1.1.1.1" "Cloudflare DNS"
+    perform_ping "208.67.222.222" "OpenDNS"
+
+    # website spiders, pings don't give us everything
+    section_header "Service and Game Site Checks"
+    check_website "https://github.com"
+    check_website "https://www.baidu.com" # chinese
+    check_website "https://www.naver.com"
+    check_website "https://www.uol.com.br" # brazil
+    check_website "https://www.timesofindia.indiatimes.com"
+    check_website "http://lobby.libretro.com/"
+    check_website "https://www.lexaloffle.com/bbs/cpost_lister3.php?cat=7"
+    
+    # download tests from some core services
+    section_header "Download Tests"
+    test_download $THEME_TEST_ASSET
+    test_download $PORTS_TEST_ASSET
+    test_download $PICO_BBS_ASSET
+    
+    # check cheevosapi status
+    check_retroachievements_api
+    
+    # check if the user is running old firmware that does not support DNS
+    check_firmware_for_dns_issue
+
+    # pull some interface config and dmesg
+    section_header "System Network Configuration"
+    log_message "Collecting network configuration information"
+    pull_common_logs
+    
+    # summary gen
+    display_summary
+
+    sync
+
+    if [ -x "${DIAGSDIR}/util_exporter.sh" ]; then
+        log_message "Executing exporter utility."
+        "${DIAGSDIR}/util_exporter.sh"
+    else
+        log_message "Exporter utility not found or not executable."
+    fi
+
+    log_message "Network checks complete."
+}
+
+main

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -39,6 +39,11 @@ section_header() {
     log_message "======== $header ========"
 }
 
+section_header_big() {
+    local header=$1
+    log_message "================ $header ================"
+}
+
 if [ -f "$LOGDIR/$LOG_EX_FILE.log" ]; then
     rm "$LOGDIR/$LOG_EX_FILE.log"
 else
@@ -74,7 +79,6 @@ check_usb_devices() {
 perform_ping() {
     local host=$1
     local service=$2
-    section_header "Ping Test for $service"
     log_message "Starting ping test for $service: $host"
     ping_total=$((ping_total + 1))
     if ping -c 1 -W 2 $host > /dev/null 2>&1; then
@@ -90,7 +94,6 @@ perform_ping() {
 check_website() {
     local url=$1
     website_total=$((website_total + 1))
-    section_header "Website Availability Check"
     log_message "Checking website availability: $url"
     if wget -q --no-check-certificate --spider $url; then
         log_message "Website $url is up.\n"
@@ -259,7 +262,7 @@ check_network_complete() {
         done
     fi
 
-    log_message "Network check complete for $interface: IP $ip_address, Subnet Mask $subnet_mask, Gateway $gateway, DNS Resolvers: $dns_resolvers"
+    log_message "Network check complete for $interface: IP $ip_address, Subnet Mask $subnet_mask, Gateway $gateway, DNS Resolvers: $dns_resolvers \n"
     return 0
 }
 
@@ -353,13 +356,13 @@ main() {
     fi
     
     # generic pings, lets see who we can hit
-    section_header "Network Ping Tests"
+    section_header_big "Network Ping Tests"
     perform_ping "8.8.8.8" "Google DNS"
     perform_ping "1.1.1.1" "Cloudflare DNS"
     perform_ping "208.67.222.222" "OpenDNS"
 
     # website spiders, pings don't give us everything
-    section_header "Service and Game Site Checks"
+    section_header_big "Service and Game Site Checks"
     check_website "https://github.com"
     check_website "https://www.baidu.com" # chinese
     check_website "https://www.naver.com"
@@ -369,7 +372,7 @@ main() {
     check_website "https://www.lexaloffle.com/bbs/cpost_lister3.php?cat=7"
     
     # download tests from some core services
-    section_header "Download Tests"
+    section_header_big "Download Tests"
     test_download $THEME_TEST_ASSET
     test_download $PORTS_TEST_ASSET
     test_download $PICO_BBS_ASSET
@@ -381,7 +384,7 @@ main() {
     check_firmware_for_dns_issue
 
     # pull some interface config and dmesg
-    section_header "System Network Configuration"
+    section_header_big "System Network Configuration"
     log_message "Collecting network configuration information"
     pull_common_logs
     

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -41,11 +41,11 @@ section_header() {
 
 section_header_big() {
     local header=$1
-    log_message "================ $header ================"
+    log_message "================================ $header ================================"
 }
 
 if [ -f "$LOGDIR/$LOG_EX_FILE.log" ]; then
-    rm "$LOGDIR/$LOG_EX_FILE.log"
+    rm "$LOGDIR/$LOG_EX_FILE.log" "$LOGDIR/network_info.log" "$LOGDIR/network_dmesg.log"
 else
     echo "$LOGDIR/$LOG_EX_FILE.log Doesn't exist"
 fi

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -312,14 +312,8 @@ if [ "$#" -gt 0 ]; then
         check_network_complete)
             check_network_complete
             ;;
-        pull_common_logs)
-            pull_common_logs
-            ;;
         check_retroachievements_api)
             check_retroachievements_api
-            ;;
-        display_summary)
-            display_summary
             ;;
         *)
             echo "Unsupported function or incorrect usage."

--- a/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_netcheck.sh
@@ -18,6 +18,7 @@ PORTS_TEST_ASSET="https://github.com/OnionUI/Ports-Collection/releases/latest/do
 PICO_BBS_ASSET="https://www.lexaloffle.com/bbs/cpost_lister3.php?cat=7"
 RA_CFG="/mnt/SDCARD/RetroArch/.retroarch/retroarch.cfg"
 RA_URL="https://retroachievements.org"
+LOG_EX_FILE="network_check"
 
 ##################
 ## LOGGING FUNCTION ##
@@ -29,7 +30,7 @@ program=$(basename "$0" .sh)
 
 log_message() {
     local message="$(date +"%Y-%m-%d %H:%M:%S") - $1"
-    echo -e "$message" >> "${LOGDIR}/network_check.log"
+    echo -e "$message" >> "${LOGDIR}/$LOG_EX_NAME.log"
     echo -e "$message" # for console
 }
 
@@ -37,6 +38,12 @@ section_header() {
     local header=$1
     log_message "======== $header ========"
 }
+
+if [ -f "$LOGDIR/$LOG_EX_FILE.log" ]; then
+    rm "$LOGDIR/$LOG_EX_FILE.log"
+else
+    echo "$LOGDIR/$LOG_EX_FILE.log Doesn't exist"
+fi
 
 ##################
 ## CHECKING      ##

--- a/static/build/.tmp_update/script/diagnostics/util_snapshot.sh
+++ b/static/build/.tmp_update/script/diagnostics/util_snapshot.sh
@@ -50,7 +50,7 @@ main() {
 snapshot() {
     system_healthcheck
     wifi_healthcheck
-    export_ra_cfg
+    # export_ra_cfg
     create_dir_logs
     create_appcfg_list
     log "Snapshot generated"


### PR DESCRIPTION
## Summary
A network check suite, quite basic for now but will help with debugging network issues as it grows. Designed to be called from the Tweaks -> Advanced -> Diagnostics menu however, can be called on the cmdline.

Will address: https://github.com/OnionUI/Onion/issues/1317 when complete

Waiting on Schmurtz to come back to check this over, we agreed on spidering for checking websites but this script can do almost all of it, just need to check the baked in domains/IP addresses against users who have issues in blocked regions (mostly China)

## Examples

### Through tweaks

When running as standalone through tweaks it will use the diagnostics framework, the script will generate an output similar to the below, which will be pushed through the exporter to an archive called `log_export.7z` on the SD root, containing some log files but most importantly these check results:

```

2024-05-13 21:50:44 - ================================ Hardware and config checks ================================
2024-05-13 21:50:44 - Check successful: Found 3 USB devices connected.
2024-05-13 21:50:44 - 8188fu driver is loaded and active.
2024-05-13 21:50:44 - WiFi is enabled, proceeding with network checks.
2024-05-13 21:50:44 - Active network interfaces found: wlan0
2024-05-13 21:50:44 - DNS Resolvers found: 192.168.1.254
2024-05-13 21:50:44 - Ping to DNS resolver 192.168.1.254 successful.
2024-05-13 21:50:44 - Network check complete for wlan0: IP 192.168.1.215, Subnet Mask 255.255.255.0, Gateway 192.168.1.254, DNS Resolvers: 192.168.1.254

2024-05-13 21:50:44 - ================================ Network Ping Tests ================================
2024-05-13 21:50:44 - Starting ping test for Google DNS: 8.8.8.8
2024-05-13 21:50:44 - Ping to 8.8.8.8 (Google DNS) successful.

2024-05-13 21:50:44 - Starting ping test for Cloudflare DNS: 1.1.1.1
2024-05-13 21:50:44 - Ping to 1.1.1.1 (Cloudflare DNS) successful.

2024-05-13 21:50:44 - Starting ping test for OpenDNS: 208.67.222.222
2024-05-13 21:50:44 - Ping to 208.67.222.222 (OpenDNS) successful.

2024-05-13 21:50:44 - ================================ Service and Game Site Checks ================================
2024-05-13 21:50:44 - Checking website availability: https://github.com
2024-05-13 21:50:45 - Website https://github.com is up.

2024-05-13 21:50:45 - Checking website availability: https://www.baidu.com
2024-05-13 21:50:47 - Website https://www.baidu.com is up.

2024-05-13 21:50:47 - Checking website availability: https://www.naver.com
2024-05-13 21:50:49 - Website https://www.naver.com is up.

2024-05-13 21:50:49 - Checking website availability: https://www.uol.com.br
2024-05-13 21:50:50 - Website https://www.uol.com.br is up.

2024-05-13 21:50:50 - Checking website availability: https://www.timesofindia.indiatimes.com
2024-05-13 21:50:51 - Website https://www.timesofindia.indiatimes.com is up.

2024-05-13 21:50:51 - Checking website availability: http://lobby.libretro.com/
2024-05-13 21:50:52 - Website http://lobby.libretro.com/ is up.

2024-05-13 21:50:52 - Checking website availability: https://www.lexaloffle.com/bbs/cpost_lister3.php?cat=7
2024-05-13 21:50:53 - Website https://www.lexaloffle.com/bbs/cpost_lister3.php?cat=7 is up.

2024-05-13 21:50:53 - ================================ Download Tests ================================
2024-05-13 21:50:53 - Testing download from: https://raw.githubusercontent.com/OnionUI/Themes/main/release/M%20by%20tenlevels.zip
2024-05-13 21:50:53 - Download test for https://raw.githubusercontent.com/OnionUI/Themes/main/release/M%20by%20tenlevels.zip was successful. Status code: 200

2024-05-13 21:50:53 - Testing download from: https://github.com/OnionUI/Ports-Collection/releases/latest/download/Sonic.Mania.7z
2024-05-13 21:50:54 - Download test for https://github.com/OnionUI/Ports-Collection/releases/latest/download/Sonic.Mania.7z was successful. Status code: 200

2024-05-13 21:50:54 - Testing download from: https://www.lexaloffle.com/bbs/cpost_lister3.php?cat=7
2024-05-13 21:50:54 - Download test for https://www.lexaloffle.com/bbs/cpost_lister3.php?cat=7 was successful. Status code: 200

2024-05-13 21:50:54 - ================================ RetroAchievements API Check ================================
2024-05-13 21:50:54 - Checking RetroAchievements API availability
2024-05-13 21:50:55 - API check was successful, returned 401 unauthorized. Status code: 401

2024-05-13 21:50:55 - ================================ Firmware DNS Check ================================
2024-05-13 21:50:55 - Firmware supports DNS, testing...

2024-05-13 21:50:55 - DNS resolution test for google.co.uk successful.

2024-05-13 21:50:55 - ================================ System Network Configuration ================================
2024-05-13 21:50:55 - Collecting network configuration information
2024-05-13 21:50:55 - ================================ Summary of Network Checks ================================
2024-05-13 21:50:55 - Ping Test Results: 3 successful out of 3 attempts.
2024-05-13 21:50:55 - Website Availability: 7 successful out of 7 checks.
2024-05-13 21:50:55 - Download Test Results: 3 successful out of 3 attempts.
2024-05-13 21:50:55 - Ping replies from all DNS providers - OK
2024-05-13 21:50:55 - Website checks - All sites are reachable
2024-05-13 21:50:55 - Download tests - All downloads successful
2024-05-13 21:50:55 - Executing exporter utility.
(util_exporter) 2024-05-13 21:50:55: Exporting and archiving logs
(util_exporter) 2024-05-13 21:50:55: Moving runtime logs
(util_exporter) 2024-05-13 21:50:56: Exported to: /mnt/SDCARD/log_export.7z
2024-05-13 21:50:56 - Network checks complete.


```
### On cmdline
It can also be called on cmdline to expose the checks to other processes, returning a 0 on success and non-zero on failure:

```sh
./util_netcheck.sh perform_ping 8.8.8.8 "Google DNS" # Quick ping, when on cmdline the second arg can be anything
./util_netcheck.sh check_website https://github.com # Spider a website
./util_netcheck.sh test_download "https://raw.githubusercontent.com/OnionUI/Themes/main/release/M%20by%20tenlevels.zip" # Test run a download
./util_netcheck.sh check_firmware_for_dns_issue # Check if the device has a firmware capable of DNS, then test DNS 
./util_netcheck.sh check_network_complete # Checks if the current network is "complete" (IP/Subnet/Gateway/DNS all valid)
./util_netcheck.sh check_retroachievements_api # Checks if the Cheevos API replies to a failed request as expected
```

```
/mnt/SDCARD/.tmp_update/script/diagnostics # ./util_netcheck.sh check_website https://github.com
2024-05-13 20:53:59 - Active network interfaces found: wlan0
2024-05-13 20:53:59 - Proceeding, valid adaptor found
2024-05-13 20:53:59 - Checking website availability: https://github.com
2024-05-13 20:54:00 - Website https://github.com is up.

/mnt/SDCARD/.tmp_update/script/diagnostics # echo $?
0
```

```
/mnt/SDCARD/.tmp_update/script/diagnostics # ./util_netcheck.sh check_website https://github2222.com
2024-05-13 20:54:39 - Active network interfaces found: wlan0
2024-05-13 20:54:39 - Proceeding, valid adaptor found
2024-05-13 20:54:39 - Checking website availability: https://github2222.com
Failed to establish connection
2024-05-13 20:54:39 - Website https://github2222.com is down.

/mnt/SDCARD/.tmp_update/script/diagnostics # echo $?
1
```