### PR TITLE
Fix for scraper script character escaping

### DIFF
--- a/static/build/.tmp_update/script/scraper/scrap_launchbox.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_launchbox.sh
@@ -235,7 +235,7 @@ set -f
 # =================
 
 if ! [ -z "$CurrentRom" ]; then
-    romfilter="-name \"*$CurrentRom*\""
+    romfilter="-name \"*$(echo $CurrentRom | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
 fi
 
 

--- a/static/build/.tmp_update/script/scraper/scrap_launchbox.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_launchbox.sh
@@ -235,7 +235,7 @@ set -f
 # =================
 
 if ! [ -z "$CurrentRom" ]; then
-    romfilter="-name \"*$(echo $CurrentRom | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
+    romfilter="-name \"*$(echo "$CurrentRom" | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
 fi
 
 

--- a/static/build/.tmp_update/script/scraper/scrap_retroarch.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_retroarch.sh
@@ -128,7 +128,7 @@ if ! [ -z "$CurrentRom" ]; then
  #   CurrentRom_noapostrophe=${CurrentRom//\'/\\\'}    # replacing   '   by    \'
  #   romfilter="-name  '*$CurrentRom_noapostrophe*'"
  #   romfilter="-name  '*$CurrentRom*'"
-    romfilter="-name \"*$(echo $CurrentRom | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
+    romfilter="-name \"*$(echo "$CurrentRom" | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
     #romfilter="-name  '*$CurrentRom*'"
     
 fi

--- a/static/build/.tmp_update/script/scraper/scrap_retroarch.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_retroarch.sh
@@ -128,7 +128,7 @@ if ! [ -z "$CurrentRom" ]; then
  #   CurrentRom_noapostrophe=${CurrentRom//\'/\\\'}    # replacing   '   by    \'
  #   romfilter="-name  '*$CurrentRom_noapostrophe*'"
  #   romfilter="-name  '*$CurrentRom*'"
-    romfilter="-name \"*$CurrentRom*\""
+    romfilter="-name \"*$(echo $CurrentRom | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
     #romfilter="-name  '*$CurrentRom*'"
     
 fi

--- a/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
@@ -387,7 +387,7 @@ if ! [ -z "$CurrentRom" ]; then
  #   romfilter="-name  '*$CurrentRom_noapostrophe*'"
  #   romfilter="-name  '*$CurrentRom*'"
     #romfilter="-name  '*$CurrentRom*'"
-    romfilter="-name \"*$CurrentRom*\""
+    romfilter="-name \"*$(echo $CurrentRom | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
 fi
     
 

--- a/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
@@ -387,7 +387,7 @@ if ! [ -z "$CurrentRom" ]; then
  #   romfilter="-name  '*$CurrentRom_noapostrophe*'"
  #   romfilter="-name  '*$CurrentRom*'"
     #romfilter="-name  '*$CurrentRom*'"
-    romfilter="-name \"*$(echo $CurrentRom | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
+    romfilter="-name \"*$(echo "$CurrentRom" | sed -e 's_\[_\\\[_g' -e 's_\]_\\\]_g')*\""
 fi
     
 


### PR DESCRIPTION
Fixes #1636

Fix for the problem with square brackets in rom names not being escaped in the scraper scripts that caused `find` not finding the rom.