### PR TITLE
Fix memory leaks with cJSON

### DIFF
--- a/src/common/system/lang.h
+++ b/src/common/system/lang.h
@@ -91,7 +91,7 @@ void lang_removeIconLabels(bool remove_icon_labels, bool remove_hints)
         }
 
         json_save(root, file_path);
-        cJSON_free(root);
+        cJSON_Delete(root);
     }
     closedir(dp);
 }
@@ -156,7 +156,7 @@ bool lang_load(void)
         }
     }
 
-    cJSON_free(lang_file);
+    cJSON_Delete(lang_file);
 
     return true;
 }

--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -155,7 +155,7 @@ void _settings_load_keymap(void)
     json_getInt(keymap, "ingame_double_press", &settings.ingame_double_press);
     json_getString(keymap, "mainui_button_x", settings.mainui_button_x);
     json_getString(keymap, "mainui_button_y", settings.mainui_button_y);
-    cJSON_free(keymap);
+    cJSON_Delete(keymap);
 }
 
 void _settings_load_mainui(void)
@@ -187,7 +187,7 @@ void _settings_load_mainui(void)
         strcpy(settings.theme, DEFAULT_THEME_PATH);
     }
 
-    cJSON_free(json_root);
+    cJSON_Delete(json_root);
 }
 
 void settings_load(void)
@@ -383,7 +383,7 @@ bool settings_saveSystemProperty(const char *prop_name, int value)
 
     cJSON_SetNumberValue(prop, value);
     json_save(json_root, MAIN_UI_SETTINGS);
-    cJSON_free(json_root);
+    cJSON_Delete(json_root);
     temp_flag_set("settings_changed", true);
 
     return true;

--- a/src/common/theme/config.h
+++ b/src/common/theme/config.h
@@ -175,7 +175,7 @@ bool theme_applyConfig(Theme_s *config, const char *config_path,
     json_getInt(json_frame, "border-left", &config->frame.border_left);
     json_getInt(json_frame, "border-right", &config->frame.border_right);
 
-    cJSON_free(json_root);
+    cJSON_Delete(json_root);
 
     return true;
 }
@@ -243,7 +243,7 @@ static bool _theme_overrides_changed = false;
 void theme_freeOverrides(void)
 {
     if (_theme_overrides != NULL)
-        cJSON_free(_theme_overrides);
+        cJSON_Delete(_theme_overrides);
     _theme_overrides = NULL;
 }
 

--- a/src/common/utils/apply_icons.h
+++ b/src/common/utils/apply_icons.h
@@ -82,7 +82,7 @@ bool apply_singleIconByFullPath(const char *config_path, const char *icon_path)
     json_forceSetString(config, "iconsel", sel_path);
 
     _saveConfigFile(config_path, cJSON_Print(config));
-    cJSON_free(config);
+    cJSON_Delete(config);
 
     return true;
 }
@@ -172,7 +172,7 @@ bool _apply_singleIconFromPack(const char *config_path,
     json_forceSetString(config, "icon", icon_path);
 
     _saveConfigFile(config_path, cJSON_Print(config));
-    cJSON_free(config);
+    cJSON_Delete(config);
 
     printf_debug("Applied icon to %s\nicon:    %s\niconsel: %s\n", config_path,
                  icon_path, sel_path);

--- a/src/common/utils/json.h
+++ b/src/common/utils/json.h
@@ -84,7 +84,7 @@ bool json_forceSetString(cJSON *object, const char *key, const char *value)
  * @brief Loads and parses a json file.
  *
  * @param file_path
- * @return cJSON* Root json object. Remember to cJSON_free the result.
+ * @return cJSON* Root json object. Remember to cJSON_Delete the result.
  */
 cJSON *json_load(const char *file_path)
 {

--- a/src/gameSwitcher/gameSwitcher.c
+++ b/src/gameSwitcher/gameSwitcher.c
@@ -895,7 +895,7 @@ int main(int argc, char *argv[])
 #endif
 
     if (json_root != NULL)
-        cJSON_free(json_root);
+        cJSON_Delete(json_root);
 
     SDL_BlitSurface(screen, NULL, video, NULL);
     SDL_Flip(video);

--- a/src/infoPanel/infoPanel.c
+++ b/src/infoPanel/infoPanel.c
@@ -75,7 +75,7 @@ static bool loadImagesPathsFromJson(const char *config_path,
         strncpy((*images_titles)[i], image_title, g_title_max_length);
     }
 
-    cJSON_free(json_root);
+    cJSON_Delete(json_root);
 
     return true;
 }

--- a/src/randomGamePicker/randomGamePicker.c
+++ b/src/randomGamePicker/randomGamePicker.c
@@ -60,13 +60,13 @@ bool loadEmuConfig(char *emupath, char *emuname_out, char *romsdir_out,
     if (romsdir_out != NULL) {
         char romsdir_rel[STR_MAX];
         if (!json_getString(json_root, "rompath", romsdir_rel)) {
-            cJSON_free(json_root);
+            cJSON_Delete(json_root);
             return false;
         }
 
         // Ignore Search results
         if (strncmp(romsdir_rel, "../../App/", 10) == 0) {
-            cJSON_free(json_root);
+            cJSON_Delete(json_root);
             return false;
         }
 
@@ -95,7 +95,7 @@ bool loadEmuConfig(char *emupath, char *emuname_out, char *romsdir_out,
                      imgpath_rel);
     }
 
-    cJSON_free(json_root);
+    cJSON_Delete(json_root);
     return true;
 }
 
@@ -285,7 +285,7 @@ bool addRandomFromJson(char *json_path)
             count++;
         }
 
-        cJSON_free(json_root);
+        cJSON_Delete(json_root);
     }
 
     total_games_count = system_count = count;

--- a/src/tweaks/icons.h
+++ b/src/tweaks/icons.h
@@ -247,14 +247,14 @@ bool _add_config_icon(const char *path, const char *name,
     cJSON *config = json_load(config_path);
 
     if (!json_getString(config, "icon", icon_path)) {
-        cJSON_free(config);
+        cJSON_Delete(config);
         return false;
     }
 
     if (!json_getString(config, "label", label))
         strncpy(label, name, STR_MAX - 1);
 
-    cJSON_free(config);
+    cJSON_Delete(config);
 
     ListItem item = {.action = action};
 


### PR DESCRIPTION
`cJSON` structures need to be deleted rather than free-ed so all sub-structures are cleaned up.

I don't think this was causing any major leaks but should now be causing no leaks :D.

See: https://github.com/OnionUI/Onion/blob/7dfc008b851398dcfe57819519efe5f958c77f65/include/cjson/cJSON.h#L146