### PR TITLE
Fix `clock` CPU utilization

### DIFF
--- a/src/clock/Makefile
+++ b/src/clock/Makefile
@@ -4,7 +4,7 @@ include ../common/config.mk
 
 TARGET = clock
 LDFLAGS := $(LDFLAGS) -lSDL -lpthread -lmi_sys -lmi_gfx
-CFLAGS := $(CFLAGS) -I./font -Os -ffunction-sections -fdata-sections
+CFLAGS := $(CFLAGS) -I./font -Os -flto -fno-fat-lto-objects
 
 include ../common/commands.mk
 include ../common/recipes.mk

--- a/src/clock/main.c
+++ b/src/clock/main.c
@@ -39,6 +39,7 @@ SOFTWARE.
 #define MAX_SECOND 59
 #define MAX_MINUTE MAX_SECOND
 #define MAX_HOUR 23
+#define MS_TO_US(ms)  ms * 1000 
 
 SDL_Surface *sdl_screen, *screen;
 
@@ -207,9 +208,10 @@ int main(int argc, char *argv[])
                           &hour_selected, &minute_selected, &seconds_selected);
 
     SDL_EnableKeyRepeat(500, 50);
-
+    int dirty = 1; // first draw
     while (!quit) {
         while (SDL_PollEvent(&event)) {
+            dirty = 1;
             switch (event.type) {
             case SDL_KEYUP:
                 switch (event.key.keysym.sym) {
@@ -296,6 +298,11 @@ int main(int argc, char *argv[])
             }
         }
 
+        if (dirty != 1) {
+            usleep(MS_TO_US(100));
+            continue;
+        }
+
         Check_leap_year();
         Dont_go_over_days();
         Dont_go_over_hour();
@@ -330,6 +337,8 @@ int main(int argc, char *argv[])
 
         /* Flip the screen so it gets displayed*/
         GFX_Flip(screen);
+
+        dirty = 0;
     }
 
     /* Make sure to clean up the allocated surfaces before exiting.


### PR DESCRIPTION
No need to redraw if there has not been any events. Poll for events about every 100 ms. Drops utilization from around 25% to less than 0.

Also swap `-ffunction-sections -fdata-sections` for LTO to save ~5 Kb of memory when loaded and probably an immeasurable amount of performance.

Below is the size difference using LTO:
![image](https://github.com/user-attachments/assets/65a585ec-3da2-4006-ae34-abca5c8eee95)

Addresses part of issue: https://github.com/OnionUI/Onion/issues/107