### PR TITLE
Common `file.c` util leaks

### DIFF
--- a/src/bootScreen/bootScreen.c
+++ b/src/bootScreen/bootScreen.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
     SDL_Color color = theme()->total.color;
 
     if (show_version) {
-        const char *version_str = file_read("/mnt/SDCARD/.tmp_update/onionVersion/version.txt");
+        char *version_str = file_read("/mnt/SDCARD/.tmp_update/onionVersion/version.txt");
         if (strlen(version_str) > 0) {
             SDL_Surface *version = TTF_RenderUTF8_Blended(font, version_str, color);
             if (version) {
@@ -75,6 +75,7 @@ int main(int argc, char *argv[])
                 SDL_FreeSurface(version);
             }
         }
+        free(version_str);
     }
 
     if (strlen(message_str) > 0) {

--- a/src/common/components/JsonGameEntry.h
+++ b/src/common/components/JsonGameEntry.h
@@ -31,6 +31,7 @@ JsonGameEntry JsonGameEntry_fromJson(const char *json_str)
     json_getInt(root, "type", &entry.type);
     json_getString(root, "rompath", entry.rompath);
     json_getString(root, "imgpath", entry.imgpath);
+    cJSON_Delete(root);
 
     strcpy(entry.emupath, entry.rompath);
     str_split(entry.emupath, "/../../");

--- a/src/common/system/lang.h
+++ b/src/common/system/lang.h
@@ -61,8 +61,9 @@ void lang_removeIconLabels(bool remove_icon_labels, bool remove_hints)
         char file_path[STR_MAX * 2];
         snprintf(file_path, STR_MAX * 2 - 1, LANG_DIR "/%s", ep->d_name);
 
-        const char *json_data = file_read(file_path);
+        char *json_data = file_read(file_path);
         cJSON *root = cJSON_Parse(json_data);
+        free(json_data);
 
         if (!root)
             continue;

--- a/src/common/system/screenshot.h
+++ b/src/common/system/screenshot.h
@@ -33,7 +33,7 @@ bool __get_path_romscreen(char *path_out)
 
 bool __get_path_recent(char *path_out)
 {
-    char *fnptr;
+    char *fnptr, *no_extension;
     uint32_t i;
 
     strcpy(path_out, "/mnt/SDCARD/Screenshots/");
@@ -43,8 +43,11 @@ bool __get_path_recent(char *path_out)
 
     if (system_state == MODE_GAME && (process_searchpid("retroarch") != 0 || process_searchpid("ra32") != 0)) {
         char file_path[STR_MAX];
-        if (history_getRecentPath(file_path) != NULL)
-            strcat(path_out, file_removeExtension(basename(file_path)));
+        if (history_getRecentPath(file_path) != NULL) {
+            no_extension = file_removeExtension(basename(file_path));
+            strcat(path_out, no_extension);
+            free(no_extension);
+        }
     }
     else if (system_state == MODE_SWITCHER)
         strcat(path_out, "GameSwitcher");
@@ -61,7 +64,9 @@ bool __get_path_recent(char *path_out)
         if (strstr(cmd, "; chmod") != NULL)
             state_getAppName(app_name, cmd);
         else {
-            strcpy(app_name, file_removeExtension(basename(cmd)));
+            no_extension = file_removeExtension(basename(cmd));
+            strcpy(app_name, no_extension);
+            free(no_extension);
         }
         printf_debug("app: '%s'\n", app_name);
 

--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -160,12 +160,13 @@ void _settings_load_keymap(void)
 
 void _settings_load_mainui(void)
 {
-    const char *json_str = NULL;
+    char *json_str = NULL;
 
     if (!(json_str = file_read(MAIN_UI_SETTINGS)))
         return;
 
     cJSON *json_root = cJSON_Parse(json_str);
+    free(json_str);
 
     json_getInt(json_root, "vol", &settings.volume);
     json_getInt(json_root, "bgmvol", &settings.bgm_volume);

--- a/src/common/system/state.h
+++ b/src/common/system/state.h
@@ -392,8 +392,10 @@ void resumeGame(int n)
             if (lineCount > 1) {
                 temp_flag_set("quick_switch", true);
 
-                file_add_line_to_beginning(getMiyooRecentFilePath(), file_read_lineN(getMiyooRecentFilePath(), lineCount));
+                char * line_n = file_read_lineN(getMiyooRecentFilePath(), lineCount);
+                file_add_line_to_beginning(getMiyooRecentFilePath(), line_n);
                 file_delete_line(getMiyooRecentFilePath(), lineCount + 1);
+                free(line_n);
             }
 
             file_put_sync(fp, CMD_TO_RUN_PATH, "%s", LaunchCommand);

--- a/src/common/system/state.h
+++ b/src/common/system/state.h
@@ -25,9 +25,10 @@ static pid_t system_state_pid = 0;
 
 bool check_isRetroArch(void)
 {
+    bool rc = false;
     if (!exists(CMD_TO_RUN_PATH))
         return false;
-    const char *cmd = file_read(CMD_TO_RUN_PATH);
+    char *cmd = file_read(CMD_TO_RUN_PATH);
     if (strstr(cmd, "retroarch") != NULL ||
         strstr(cmd, "/mnt/SDCARD/Emu/") != NULL ||
         strstr(cmd, "/mnt/SDCARD/RApp/") != NULL) {
@@ -35,10 +36,11 @@ bool check_isRetroArch(void)
         if ((pid = process_searchpid("retroarch")) != 0 ||
             (pid = process_searchpid("ra32")) != 0) {
             system_state_pid = pid;
-            return true;
+            rc = true;
         }
     }
-    return false;
+    free(cmd);
+    return rc;
 }
 
 bool check_isMainUI(void)

--- a/src/common/theme/config.h
+++ b/src/common/theme/config.h
@@ -95,13 +95,14 @@ void json_fontStyle(cJSON *root, FontStyle_s *dest, FontStyle_s *fallback)
 bool theme_applyConfig(Theme_s *config, const char *config_path,
                        bool use_fallbacks)
 {
-    const char *json_str = NULL;
+    char *json_str = NULL;
 
     if (!exists(config_path) || !(json_str = file_read(config_path)))
         return false;
 
     // Get JSON objects
     cJSON *json_root = cJSON_Parse(json_str);
+    free(json_str);
     cJSON *json_batteryPercentage =
         cJSON_GetObjectItem(json_root, "batteryPercentage");
     cJSON *json_hideLabels = cJSON_GetObjectItem(json_root, "hideLabels");

--- a/src/common/utils/apply_icons.h
+++ b/src/common/utils/apply_icons.h
@@ -140,8 +140,7 @@ bool _apply_singleIconFromPack(const char *config_path,
     if (!json_getString(config, "icon", temp_path))
         return false;
 
-    char icon_name[56];
-    strncpy(icon_name, file_removeExtension(basename(temp_path)), 55);
+    char *icon_name = file_removeExtension(basename(temp_path));
     str_split(icon_name, "-");
 
     IconMode_e mode = icons_getIconMode(config_path);
@@ -156,13 +155,16 @@ bool _apply_singleIconFromPack(const char *config_path,
                     icon_name);
         }
 
-        if (!is_file(icon_path))
+        if (!is_file(icon_path)) {
+            free(icon_name);
             return false;
+        }
     }
 
     char sel_path[STR_MAX];
     sprintf(sel_path, icons_getSelectedIconPathFormat(mode), icon_pack_path,
             icon_name);
+    free(icon_name);
 
     if (is_file(sel_path))
         json_forceSetString(config, "iconsel", sel_path);

--- a/src/common/utils/apply_icons.h
+++ b/src/common/utils/apply_icons.h
@@ -183,7 +183,7 @@ bool _apply_singleIconFromPack(const char *config_path,
 bool apply_singleIcon(const char *config_path)
 {
     char icon_pack_path[STR_MAX];
-    const char *active_icon_pack = file_read(ACTIVE_ICON_PACK);
+    char *active_icon_pack = file_read(ACTIVE_ICON_PACK);
 
     if (active_icon_pack != NULL && is_dir(active_icon_pack))
         strncpy(icon_pack_path, active_icon_pack, STR_MAX - 1);
@@ -199,6 +199,7 @@ bool apply_singleIcon(const char *config_path)
         _apply_singleIconFromPack(GUEST_ON_CONFIG, icon_pack_path, false);
     }
 
+    free(active_icon_pack);
     return _apply_singleIconFromPack(config_path, icon_pack_path, false);
 }
 

--- a/src/common/utils/file.c
+++ b/src/common/utils/file.c
@@ -100,7 +100,7 @@ void file_readLastLine(const char *filename, char *out_str)
     }
 }
 
-const char *file_read(const char *path)
+char *file_read(const char *path)
 {
     FILE *f = NULL;
     char *buffer = NULL;

--- a/src/common/utils/file.c
+++ b/src/common/utils/file.c
@@ -48,6 +48,12 @@ bool file_isModified(const char *path, time_t *old_mtime)
     return false;
 }
 
+const char *file_basename(const char *filename)
+{
+    char *p = strrchr(filename, '/');
+    return p ? p + 1 : (char *) filename;
+}
+
 /**
  * @brief Create directories in dir_path using `mkdir -p` command.
  *
@@ -141,7 +147,7 @@ void file_copy(const char *src_path, const char *dest_path)
     system(system_cmd);
 }
 
-char *file_removeExtension(char *myStr)
+char *file_removeExtension(const char *myStr)
 {
     if (myStr == NULL)
         return NULL;
@@ -173,7 +179,7 @@ char *extractPath(const char *absolutePath)
 
 void file_cleanName(char *name_out, const char *file_name)
 {
-    char *name_without_ext = file_removeExtension(strdup(file_name));
+    char *name_without_ext = file_removeExtension(file_name);
     char *no_underscores = str_replace(name_without_ext, "_", " ");
     char *dot_ptr = strstr(no_underscores, ".");
     if (dot_ptr != NULL) {

--- a/src/common/utils/file.c
+++ b/src/common/utils/file.c
@@ -456,7 +456,9 @@ void file_add_line_to_beginning(const char *filename, const char *lineToAdd)
         return;
     }
     char tempPath[STR_MAX];
-    sprintf(tempPath, "%s/temp.txt", extractPath(filename));
+    char *path = extractPath(filename);
+    sprintf(tempPath, "%s/temp.txt", path);
+    free(path);
 
     FILE *tempFile = fopen(tempPath, "w");
     if (tempFile == NULL) {

--- a/src/common/utils/file.h
+++ b/src/common/utils/file.h
@@ -76,7 +76,7 @@ bool mkdirs(const char *dir_path);
 
 void file_readLastLine(const char *filename, char *out_str);
 
-const char *file_read(const char *path);
+char *file_read(const char *path);
 
 bool file_write(const char *path, const char *str, uint32_t len);
 

--- a/src/common/utils/file.h
+++ b/src/common/utils/file.h
@@ -93,15 +93,15 @@ bool mkdirs(const char *dir_path);
 
 void file_readLastLine(const char *filename, char *out_str);
 
-char *file_read(const char *path);
+char *file_read(const char *path) __attribute__((malloc));
 
 bool file_write(const char *path, const char *str, uint32_t len);
 
 void file_copy(const char *src_path, const char *dest_path);
 
-char *file_removeExtension(const char *myStr);
+char *file_removeExtension(const char *myStr) __attribute__((malloc));
 
-char *extractPath(const char *absolutePath);
+char *extractPath(const char *absolutePath) __attribute__((malloc));
 
 char *extractLastDirectory(const char *path);
 
@@ -121,7 +121,7 @@ bool file_findNewest(const char *dir_path, char *newest_file, size_t buffer_size
 
 FILE *file_open_ensure_path(const char *path, const char *mode);
 
-char *file_read_lineN(const char *filename, int n);
+char *file_read_lineN(const char *filename, int n) __attribute__((malloc));
 
 void file_delete_line(const char *fileName, int n);
 

--- a/src/common/utils/file.h
+++ b/src/common/utils/file.h
@@ -66,6 +66,23 @@ bool is_dir(const char *file_path);
 bool file_isModified(const char *path, time_t *old_mtime);
 
 /**
+ * @brief returns the filename component of a path
+ * 
+ * This is a copy of the GNU `basename` version and
+ * retains all the quirks that come along with it
+ * 
+ * See 'Versions' here:
+ * https://man7.org/linux/man-pages/man3/basename.3.html
+ * 
+ * Copied from: 
+ * https://sourceware.org/git/?p=glibc.git;a=blob;f=string/basename.c;h=d5b5d4763dd3fa307497cc99788b0bb24c95bcf1;hb=refs/heads/master#l22
+ * 
+ * @param filename The full file path.
+ * @return * char* 
+ */
+const char *file_basename(const char *filename);
+
+/**
  * @brief Create directories in dir_path using `mkdir -p` command.
  *
  * @param dir_path The full directory path.
@@ -82,7 +99,7 @@ bool file_write(const char *path, const char *str, uint32_t len);
 
 void file_copy(const char *src_path, const char *dest_path);
 
-char *file_removeExtension(char *myStr);
+char *file_removeExtension(const char *myStr);
 
 char *extractPath(const char *absolutePath);
 

--- a/src/common/utils/json.h
+++ b/src/common/utils/json.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "./file.h"
 #include "cjson/cJSON.h"
@@ -88,7 +89,10 @@ bool json_forceSetString(cJSON *object, const char *key, const char *value)
  */
 cJSON *json_load(const char *file_path)
 {
-    return cJSON_Parse(file_read(file_path));
+    char *file_contents = file_read(file_path);
+    cJSON *json_contents = cJSON_Parse(file_contents);
+    free(file_contents);
+    return json_contents;
 }
 
 void json_save(cJSON *object, char *file_path)

--- a/src/gameSwitcher/gameSwitcher.c
+++ b/src/gameSwitcher/gameSwitcher.c
@@ -187,7 +187,9 @@ void getGameName(char *name_out, const char *rom_path)
         free(cache_item);
     }
     else {
-        strcpy(name_out, file_removeExtension(basename(strdup(rom_path))));
+        char *no_extension = file_removeExtension(file_basename(rom_path));
+        strcpy(name_out, no_extension);
+        free(no_extension);
     }
 }
 

--- a/src/infoPanel/infoPanel.c
+++ b/src/infoPanel/infoPanel.c
@@ -30,7 +30,7 @@ static bool loadImagesPathsFromJson(const char *config_path,
                                     int *images_paths_count,
                                     char ***images_titles)
 {
-    const char *json_str = NULL;
+    char *json_str = NULL;
 
     char temp_path[STR_MAX];
     strncpy(temp_path, config_path, STR_MAX - 1);
@@ -42,6 +42,7 @@ static bool loadImagesPathsFromJson(const char *config_path,
 
     // Get JSON objects
     cJSON *json_root = cJSON_Parse(json_str);
+    free(json_str);
     cJSON *json_images_array = cJSON_GetObjectItem(json_root, "images");
     *images_paths_count = cJSON_GetArraySize(json_images_array);
     *images_paths = (char **)malloc(*images_paths_count * sizeof(char *));

--- a/src/infoPanel/infoPanel.c
+++ b/src/infoPanel/infoPanel.c
@@ -363,10 +363,12 @@ int main(int argc, char *argv[])
                                 g_image_index >= 0) {
                                 current_image_path = g_images_paths[g_image_index];
                             }
+                            char *no_extension = file_removeExtension(basename(current_image_path));
                             theme_renderHeader(
                                 screen,
-                                file_removeExtension(basename(current_image_path)),
+                                no_extension,
                                 false);
+                            free(no_extension);
                         }
                     }
 

--- a/src/playActivity/cacheDB.h
+++ b/src/playActivity/cacheDB.h
@@ -117,7 +117,7 @@ CacheDBItem *cache_db_find(const char *path_or_name)
     char *sql;
     int cache_version = cache_get_path(cache_db_file_path, cache_type, path_or_name);
 
-    char *game_name = file_removeExtension(basename(strdup(path_or_name)));
+    char *game_name = file_removeExtension(file_basename(path_or_name));
 
     if (cache_version == 2) {
         sql = sqlite3_mprintf("SELECT disp, path, imgpath FROM %q_roms WHERE path LIKE '%%%q' OR disp = %Q LIMIT 1;", cache_type, rel_path, game_name);
@@ -129,6 +129,7 @@ CacheDBItem *cache_db_find(const char *path_or_name)
         printf("No cache db found\n");
         return NULL;
     }
+    free(game_name);
 
     sqlite3_stmt *stmt = cache_db_prepare(cache_db_file_path, sql);
     sqlite3_free(sql);

--- a/src/playActivity/migrateDB.h
+++ b/src/playActivity/migrateDB.h
@@ -136,11 +136,14 @@ void migrateDB(void)
 
             while (sqlite3_step(stmt) == SQLITE_ROW && is_found == false) {
                 char *rom_path = (char *)sqlite3_column_text(stmt, 1);
+                char *no_extension = file_removeExtension(rom_path);
 
                 if (strcmp(basename(rom_path), rom_list[i].name) != 0 &&
-                    strcmp(basename(file_removeExtension(rom_path)), rom_list[i].name) != 0) {
+                    strcmp(basename(no_extension), rom_list[i].name) != 0) {
+                    free(no_extension);
                     continue;
                 }
+                free(no_extension);
 
                 is_found = true;
 

--- a/src/playActivity/playActivityDB.h
+++ b/src/playActivity/playActivityDB.h
@@ -58,6 +58,7 @@ void get_rom_image_path(char *rom_file, char *out_image_path)
     char *rom_folder = strtok(rom_file, "/");
 
     snprintf(out_image_path, STR_MAX - 1, "/mnt/SDCARD/Roms/%s/Imgs/%s.png", rom_folder, clean_rom_name);
+    free(clean_rom_name);
 }
 
 void play_activity_db_close()
@@ -283,12 +284,15 @@ void __db_update_rom_from_cache(int rom_id, CacheDBItem *cache_db_item)
 int __db_get_orphan_rom_id(const char *rom_path)
 {
     int rom_id = ROM_NOT_FOUND;
-    char *file_name = basename(strdup(rom_path));
+    char *_file_name = strdup(rom_path);
+    char *file_name = basename(_file_name);
     char *rom_name = file_removeExtension(file_name);
 
     char *sql = sqlite3_mprintf("SELECT id FROM rom WHERE (name=%Q OR name=%Q) AND type='ORPHAN' LIMIT 1;", rom_name, file_name);
     sqlite3_stmt *stmt = play_activity_db_prepare(sql);
     sqlite3_free(sql);
+    free(rom_name);
+    free(_file_name);
 
     if (sqlite3_step(stmt) == SQLITE_ROW) {
         rom_id = sqlite3_column_int(stmt, 0);
@@ -348,8 +352,9 @@ int __db_rom_find_by_file_path(const char *rom_path, bool create_or_update)
             free(cache_db_item);
         }
         else {
-            const char *rom_name = file_removeExtension(basename(strdup(rom_path)));
+            char *rom_name = file_removeExtension(file_basename(rom_path));
             __db_update_rom(rom_id, "", rom_name, rom_path, "");
+            free(rom_name);
         }
     }
     else if (rom_id == ROM_NOT_FOUND && create_or_update) {
@@ -360,8 +365,9 @@ int __db_rom_find_by_file_path(const char *rom_path, bool create_or_update)
             free(cache_db_item);
         }
         else {
-            const char *rom_name = file_removeExtension(basename(strdup(rom_path)));
+            char *rom_name = file_removeExtension(file_basename(rom_path));
             rom_id = __db_insert_rom("", rom_name, rom_path, "");
+            free(rom_name);
         }
     }
 

--- a/src/randomGamePicker/randomGamePicker.c
+++ b/src/randomGamePicker/randomGamePicker.c
@@ -278,8 +278,10 @@ bool addRandomFromJson(char *json_path)
                 continue;
 
             if (strlen(game->img_path) == 0) {
+                char *no_extension = file_removeExtension(basename(game->path));
                 snprintf(game->img_path, STR_MAX * 3 + 2, "%s/%s.png", imgsdir,
-                         file_removeExtension(basename(game->path)));
+                         no_extension);
+                free(no_extension);
             }
 
             count++;

--- a/src/renameRom/renameRom.c
+++ b/src/renameRom/renameRom.c
@@ -128,6 +128,7 @@ int main(int argc, char *argv[])
     if (!renameFile(imgdir, "png", old_name, new_name)) {
         print_debug("No box art found");
     }
+    free(old_name);
 
     // Rename cache entry
 

--- a/src/renameRom/renameRom.c
+++ b/src/renameRom/renameRom.c
@@ -116,8 +116,9 @@ int main(int argc, char *argv[])
     if (!is_file(config_path))
         return 0;
 
-    const char *config_str = file_read(config_path);
+    char *config_str = file_read(config_path);
     JsonGameEntry config = JsonGameEntry_fromJson(config_str);
+    free(config_str);
 
     // Rename box art
 

--- a/src/tweaks/icons.h
+++ b/src/tweaks/icons.h
@@ -33,7 +33,7 @@ int _add_icon_alts(const char *pack_dir, const char *pack_name,
 {
     DIR *dp;
     struct dirent *ep;
-    char icon_name[STR_MAX];
+    char *icon_name;
     char alt_name[STR_MAX];
     char preview_path[STR_MAX * 2 + 1];
     int count = 0;
@@ -48,9 +48,10 @@ int _add_icon_alts(const char *pack_dir, const char *pack_name,
 
             snprintf(preview_path, STR_MAX * 2, "%s/%s", pack_dir, ep->d_name);
 
-            strncpy(icon_name, ep->d_name, STR_MAX - 1);
-            snprintf(alt_name, STR_MAX - 1, "%s - %s", pack_name,
-                     file_removeExtension(str_split(icon_name, "-")));
+            icon_name = file_removeExtension(ep->d_name);
+            str_split(icon_name, "-");
+            snprintf(alt_name, STR_MAX - 1, "%s - %s", pack_name, icon_name);
+            free(icon_name);
 
             ListItem item = {.action = action};
             strncpy(item.label, alt_name, STR_MAX - 1);
@@ -236,7 +237,7 @@ bool _add_config_icon(const char *path, const char *name,
                       void (*action)(void *))
 {
     char label[STR_MAX];
-    char icon_name[56];
+    char *icon_name;
     char icon_path[STR_MAX];
     char preview_path[STR_MAX * 2 + 32];
     IconMode_e mode = icons_getIconMode(config_path);
@@ -267,7 +268,7 @@ bool _add_config_icon(const char *path, const char *name,
     char abs_path[STR_MAX - 56];
     realpath(preview_path, abs_path);
 
-    strncpy(icon_name, file_removeExtension(basename(icon_path)), 55);
+    icon_name = file_removeExtension(basename(icon_path));
     str_split(icon_name, "-");
 
     char short_label[56];
@@ -293,6 +294,7 @@ bool _add_config_icon(const char *path, const char *name,
         item.icon_ptr = (void *)IMG_Load(preview_path);
 
     list_addItem(list, item);
+    free(icon_name);
 
     return true;
 }


### PR DESCRIPTION
Because `file_read` allocates memory, it should be free-ed. Currently,
attempting to do so will cause a compiler warning since `free` does
not take `const` qualified pointer (because we are modifying the
memory).

Changing the return type to `char *` rather than `const char *` will
allow the caller to correctly free memory.

Also fix most of the transitive leaks I could find. e.x. `strdup` returns allocated memory that should be free-ed.

Last patch doesn't really fix anything but adds the `malloc` function attribute for the compiler but also to hint to developers that the function allocates memory that needs to be free-ed.