### PR TITLE
Implement RTC detection for devices that have it (newer MM+)

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -763,14 +763,22 @@ save_settings() {
 }
 
 update_time() {
-    # Give hardware modders an option to disable time restore
-    if [ -f $sysdir/config/.noTimeRestore ]; then
+    # Detect RTC, if available, do not restore time
+    rtc_treshold=15 # usually around 3-5 at this point
+    current_time=$(date +%s)
+
+    if [ "$current_time" -gt "$rtc_treshold" ]; then
+        log "RTC available, not restoring time. Current time: $current_time"
         return
+    else
+        log "RTC not available, restoring time. Current time: $current_time"
     fi
+
     timepath=/mnt/SDCARD/Saves/CurrentProfile/saves/currentTime.txt
     currentTime=0
     # Load current time
     if [ -f $timepath ]; then
+        log "Restoring time"
         currentTime=$(cat $timepath)
     fi
     date +%s -s @$currentTime

--- a/website/docs/07-apps/01-included-in-onion/clock.md
+++ b/website/docs/07-apps/01-included-in-onion/clock.md
@@ -9,8 +9,7 @@ description: Set your Onion's time
 ## Presentation
 
 Simple clock app which allows you to manually set the clock of your device. Especially useful for the Miyoo Mini which doesn't have an internal RTC (which means that the time is reset at each boot). By default, Onion preserves the current time during shutdown, and upon the subsequent boot, it is restored with 4 hours added.
-
-If you don't want the device to restore the time on boot (e.g. you have modded your device to have hardware RTC), you can create the file `SDCARD\.tmp_update\config\.noTimeRestore`. Doing so will prevent the time restore.
+If RTC is present, which is the case with newer Miyoo Mini+, or if it is modded in, the time is not restored or advanced but will instead be set by RTC.
 
 ![](./assets/clock.png)
 


### PR DESCRIPTION
Since the newest hardware revisions of the Miyoo Mini+ have RTC, it should be handled accordingly.

Detects if RTC is present, and does not restore and/or advance time if it is.
Works with newest Miyoo Mini+ with built in RTC as well as modded in RTC.

Edit: will also work on MM with RTC, see #1673