### PR TITLE
Enable blue light schedule to work for Miyoo Minis with RTC

### DIFF
--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -66,6 +66,7 @@ typedef struct settings_s {
     int blue_light_rgb;
     char blue_light_time[16];
     char blue_light_time_off[16];
+    bool no_time_restore;
 
     char mainui_button_x[JSON_STRING_LEN];
     char mainui_button_y[JSON_STRING_LEN];
@@ -103,6 +104,7 @@ static settings_s __default_settings = (settings_s){
     .vibration = 2,
     .startup_tab = 0,
     .startup_application = 0,
+    .no_time_restore = false,
     // Menu button actions
     .mainui_single_press = 1,
     .mainui_long_press = 0,
@@ -206,7 +208,7 @@ void settings_load(void)
     settings.blue_light_schedule = config_flag_get(".blf");
     settings.rec_indicator = config_flag_get(".recIndicator");
     settings.rec_hotkey = config_flag_get(".recHotkey");
-    settings.noTimeRestore = config_flag_get(".noTimeRestore");
+    settings.no_time_restore = config_flag_get(".noTimeRestore");
 
     if (config_flag_get(".noLowBatteryAutoSave")) // flag is deprecated, but keep compatibility
         settings.low_battery_autosave_at = 0;

--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -206,6 +206,7 @@ void settings_load(void)
     settings.blue_light_schedule = config_flag_get(".blf");
     settings.rec_indicator = config_flag_get(".recIndicator");
     settings.rec_hotkey = config_flag_get(".recHotkey");
+    settings.noTimeRestore = config_flag_get(".noTimeRestore");
 
     if (config_flag_get(".noLowBatteryAutoSave")) // flag is deprecated, but keep compatibility
         settings.low_battery_autosave_at = 0;

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -823,9 +823,7 @@ int main(void)
         }
 
         // Check bluelight filter
-        if (DEVICE_ID == MIYOO354) {
-            system("/mnt/SDCARD/.tmp_update/script/blue_light.sh check");
-        }
+        system("/mnt/SDCARD/.tmp_update/script/blue_light.sh check");
 
         // Quit RetroArch / auto-save when battery too low
         if (settings.low_battery_autosave_at && battery_getPercentage() <= settings.low_battery_autosave_at && check_autosave()) {

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -823,7 +823,7 @@ int main(void)
         }
 
         // Check bluelight filter
-        if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
+        if (settings.blue_light_schedule) {
             system("/mnt/SDCARD/.tmp_update/script/blue_light.sh check");
         }
 

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -823,7 +823,9 @@ int main(void)
         }
 
         // Check bluelight filter
-        system("/mnt/SDCARD/.tmp_update/script/blue_light.sh check");
+        if (DEVICE_ID == MIYOO354) {
+            system("/mnt/SDCARD/.tmp_update/script/blue_light.sh check");
+        }
 
         // Quit RetroArch / auto-save when battery too low
         if (settings.low_battery_autosave_at && battery_getPercentage() <= settings.low_battery_autosave_at && check_autosave()) {

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -823,7 +823,7 @@ int main(void)
         }
 
         // Check bluelight filter
-        if (DEVICE_ID == MIYOO354) {
+        if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
             system("/mnt/SDCARD/.tmp_update/script/blue_light.sh check");
         }
 

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -484,13 +484,11 @@ void menu_blueLight(void *_)
     if (!_menu_user_blue_light._created) {
         network_loadState();
         _menu_user_blue_light = list_createWithTitle(6, LIST_SMALL, "Blue light filter");
-        if (DEVICE_ID == MIYOO354) {
-            list_addItem(&_menu_user_blue_light,
-                         (ListItem){
-                             .label = "[DATESTRING]",
-                             .disabled = 1,
-                             .action = NULL});
-        }
+        list_addItem(&_menu_user_blue_light,
+                        (ListItem){
+                            .label = "[DATESTRING]",
+                            .disabled = 1,
+                            .action = NULL});
         list_addItemWithInfoNote(&_menu_user_blue_light,
                                  (ListItem){
                                      .label = "State",
@@ -500,16 +498,13 @@ void menu_blueLight(void *_)
                                      .value = (int)settings.blue_light_state || exists("/tmp/.blfOn"),
                                      .action = action_blueLight},
                                  "Set the selected strength now\n");
-        if (DEVICE_ID == MIYOO354) {
-            list_addItemWithInfoNote(&_menu_user_blue_light,
-                                     (ListItem){
-                                         .label = "",
-                                         .disabled = !network_state.ntp,
-                                         .item_type = TOGGLE,
-                                         .value = (int)settings.blue_light_schedule,
-                                         .action = action_blueLightSchedule},
-                                     "Enable or disable the bluelight filter schedule\n");
-        }
+        list_addItemWithInfoNote(&_menu_user_blue_light,
+                                    (ListItem){
+                                        .label = "",
+                                        .item_type = TOGGLE,
+                                        .value = (int)settings.blue_light_schedule,
+                                        .action = action_blueLightSchedule},
+                                    "Enable or disable the bluelight filter schedule\n");
         list_addItemWithInfoNote(&_menu_user_blue_light,
                                  (ListItem){
                                      .label = "Strength",
@@ -522,35 +517,29 @@ void menu_blueLight(void *_)
                                      .value = value_blueLightLevel()},
                                  "Change the strength of the \n"
                                  "Blue light filter");
-        if (DEVICE_ID == MIYOO354) {
-            list_addItemWithInfoNote(&_menu_user_blue_light,
-                                     (ListItem){
-                                         .label = "Time (On)",
-                                         .disabled = !network_state.ntp,
-                                         .item_type = MULTIVALUE,
-                                         .value_max = 95,
-                                         .value_formatter = formatter_Time,
-                                         .action = action_blueLightTimeOn,
-                                         .value = value_blueLightTimeOn()},
-                                     "Time schedule for the bluelight filter");
-            list_addItemWithInfoNote(&_menu_user_blue_light,
-                                     (ListItem){
-                                         .label = "Time (Off)",
-                                         .disabled = !network_state.ntp,
-                                         .item_type = MULTIVALUE,
-                                         .value_max = 95,
-                                         .value_formatter = formatter_Time,
-                                         .action = action_blueLightTimeOff,
-                                         .value = value_blueLightTimeOff()},
-                                     "Time schedule for the bluelight filter");
-        }
+        list_addItemWithInfoNote(&_menu_user_blue_light,
+                                    (ListItem){
+                                        .label = "Time (On)",
+                                        .item_type = MULTIVALUE,
+                                        .value_max = 95,
+                                        .value_formatter = formatter_Time,
+                                        .action = action_blueLightTimeOn,
+                                        .value = value_blueLightTimeOn()},
+                                    "Time schedule for the bluelight filter");
+        list_addItemWithInfoNote(&_menu_user_blue_light,
+                                    (ListItem){
+                                        .label = "Time (Off)",
+                                        .item_type = MULTIVALUE,
+                                        .value_max = 95,
+                                        .value_formatter = formatter_Time,
+                                        .action = action_blueLightTimeOff,
+                                        .value = value_blueLightTimeOff()},
+                                    "Time schedule for the bluelight filter");
     }
-    if (DEVICE_ID == MIYOO354) {
-        _writeDateString(_menu_user_blue_light.items[0].label);
-        char scheduleToggleLabel[100];
-        strcpy(scheduleToggleLabel, exists("/tmp/.blfIgnoreSchedule") ? "Schedule (ignored)" : "Schedule");
-        strcpy(_menu_user_blue_light.items[2].label, scheduleToggleLabel);
-    }
+    _writeDateString(_menu_user_blue_light.items[0].label);
+    char scheduleToggleLabel[100];
+    strcpy(scheduleToggleLabel, exists("/tmp/.blfIgnoreSchedule") ? "Schedule (ignored)" : "Schedule");
+    strcpy(_menu_user_blue_light.items[2].label, scheduleToggleLabel);
     menu_stack[++menu_level] = &_menu_user_blue_light;
     header_changed = true;
 }

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -481,8 +481,8 @@ void menu_themeOverrides(void *_)
 
 void menu_blueLight(void *_)
 {
-    bool schedule_show = (DEVICE_ID == MIYOO354 || settings.noTimeRestore || settings.blue_light_schedule);
-    bool schedule_disable = (!settings.noTimeRestore && !network_state.ntp && !settings.blue_light_schedule);
+    bool schedule_show = (DEVICE_ID == MIYOO354 || settings.no_time_restore || settings.blue_light_schedule);
+    bool schedule_disable = (!settings.no_time_restore && !network_state.ntp && !settings.blue_light_schedule);
     if (!_menu_user_blue_light._created) {
         network_loadState();
         _menu_user_blue_light = list_createWithTitle(6, LIST_SMALL, "Blue light filter");

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -481,10 +481,12 @@ void menu_themeOverrides(void *_)
 
 void menu_blueLight(void *_)
 {
+    bool schedule_show = (DEVICE_ID == MIYOO354 || settings.noTimeRestore || settings.blue_light_schedule);
+    bool schedule_disable = (!settings.noTimeRestore && !network_state.ntp && !settings.blue_light_schedule);
     if (!_menu_user_blue_light._created) {
         network_loadState();
         _menu_user_blue_light = list_createWithTitle(6, LIST_SMALL, "Blue light filter");
-        if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
+        if (schedule_show) {
             list_addItem(&_menu_user_blue_light,
                          (ListItem){
                              .label = "[DATESTRING]",
@@ -500,11 +502,11 @@ void menu_blueLight(void *_)
                                      .value = (int)settings.blue_light_state || exists("/tmp/.blfOn"),
                                      .action = action_blueLight},
                                  "Set the selected strength now\n");
-        if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
+        if (schedule_show) {
             list_addItemWithInfoNote(&_menu_user_blue_light,
                                      (ListItem){
                                          .label = "",
-                                         .disabled = (!settings.noTimeRestore && !network_state.ntp),
+                                         .disabled = schedule_disable,
                                          .item_type = TOGGLE,
                                          .value = (int)settings.blue_light_schedule,
                                          .action = action_blueLightSchedule},
@@ -522,11 +524,11 @@ void menu_blueLight(void *_)
                                      .value = value_blueLightLevel()},
                                  "Change the strength of the \n"
                                  "Blue light filter");
-        if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
+        if (schedule_show) {
             list_addItemWithInfoNote(&_menu_user_blue_light,
                                      (ListItem){
                                          .label = "Time (On)",
-                                         .disabled = (!settings.noTimeRestore && !network_state.ntp),
+                                         .disabled = schedule_disable,
                                          .item_type = MULTIVALUE,
                                          .value_max = 95,
                                          .value_formatter = formatter_Time,
@@ -536,7 +538,7 @@ void menu_blueLight(void *_)
             list_addItemWithInfoNote(&_menu_user_blue_light,
                                      (ListItem){
                                          .label = "Time (Off)",
-                                         .disabled = (!settings.noTimeRestore && !network_state.ntp),
+                                         .disabled = schedule_disable,
                                          .item_type = MULTIVALUE,
                                          .value_max = 95,
                                          .value_formatter = formatter_Time,
@@ -545,7 +547,7 @@ void menu_blueLight(void *_)
                                      "Time schedule for the bluelight filter");
         }
     }
-    if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
+    if (schedule_show) {
         _writeDateString(_menu_user_blue_light.items[0].label);
         char scheduleToggleLabel[100];
         strcpy(scheduleToggleLabel, exists("/tmp/.blfIgnoreSchedule") ? "Schedule (ignored)" : "Schedule");

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -484,7 +484,7 @@ void menu_blueLight(void *_)
     if (!_menu_user_blue_light._created) {
         network_loadState();
         _menu_user_blue_light = list_createWithTitle(6, LIST_SMALL, "Blue light filter");
-        if (DEVICE_ID == MIYOO354) {
+        if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
             list_addItem(&_menu_user_blue_light,
                          (ListItem){
                              .label = "[DATESTRING]",
@@ -500,11 +500,11 @@ void menu_blueLight(void *_)
                                      .value = (int)settings.blue_light_state || exists("/tmp/.blfOn"),
                                      .action = action_blueLight},
                                  "Set the selected strength now\n");
-        if (DEVICE_ID == MIYOO354) {
+        if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
             list_addItemWithInfoNote(&_menu_user_blue_light,
                                      (ListItem){
                                          .label = "",
-                                         .disabled = !network_state.ntp,
+                                         .disabled = (!settings.noTimeRestore && !network_state.ntp),
                                          .item_type = TOGGLE,
                                          .value = (int)settings.blue_light_schedule,
                                          .action = action_blueLightSchedule},
@@ -522,11 +522,11 @@ void menu_blueLight(void *_)
                                      .value = value_blueLightLevel()},
                                  "Change the strength of the \n"
                                  "Blue light filter");
-        if (DEVICE_ID == MIYOO354) {
+        if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
             list_addItemWithInfoNote(&_menu_user_blue_light,
                                      (ListItem){
                                          .label = "Time (On)",
-                                         .disabled = !network_state.ntp,
+                                         .disabled = (!settings.noTimeRestore && !network_state.ntp),
                                          .item_type = MULTIVALUE,
                                          .value_max = 95,
                                          .value_formatter = formatter_Time,
@@ -536,7 +536,7 @@ void menu_blueLight(void *_)
             list_addItemWithInfoNote(&_menu_user_blue_light,
                                      (ListItem){
                                          .label = "Time (Off)",
-                                         .disabled = !network_state.ntp,
+                                         .disabled = (!settings.noTimeRestore && !network_state.ntp),
                                          .item_type = MULTIVALUE,
                                          .value_max = 95,
                                          .value_formatter = formatter_Time,
@@ -545,7 +545,7 @@ void menu_blueLight(void *_)
                                      "Time schedule for the bluelight filter");
         }
     }
-    if (DEVICE_ID == MIYOO354) {
+    if (DEVICE_ID == MIYOO354 || settings.noTimeRestore) {
         _writeDateString(_menu_user_blue_light.items[0].label);
         char scheduleToggleLabel[100];
         strcpy(scheduleToggleLabel, exists("/tmp/.blfIgnoreSchedule") ? "Schedule (ignored)" : "Schedule");

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -484,11 +484,13 @@ void menu_blueLight(void *_)
     if (!_menu_user_blue_light._created) {
         network_loadState();
         _menu_user_blue_light = list_createWithTitle(6, LIST_SMALL, "Blue light filter");
-        list_addItem(&_menu_user_blue_light,
-                        (ListItem){
-                            .label = "[DATESTRING]",
-                            .disabled = 1,
-                            .action = NULL});
+        if (DEVICE_ID == MIYOO354) {
+            list_addItem(&_menu_user_blue_light,
+                         (ListItem){
+                             .label = "[DATESTRING]",
+                             .disabled = 1,
+                             .action = NULL});
+        }
         list_addItemWithInfoNote(&_menu_user_blue_light,
                                  (ListItem){
                                      .label = "State",
@@ -498,13 +500,16 @@ void menu_blueLight(void *_)
                                      .value = (int)settings.blue_light_state || exists("/tmp/.blfOn"),
                                      .action = action_blueLight},
                                  "Set the selected strength now\n");
-        list_addItemWithInfoNote(&_menu_user_blue_light,
-                                    (ListItem){
-                                        .label = "",
-                                        .item_type = TOGGLE,
-                                        .value = (int)settings.blue_light_schedule,
-                                        .action = action_blueLightSchedule},
-                                    "Enable or disable the bluelight filter schedule\n");
+        if (DEVICE_ID == MIYOO354) {
+            list_addItemWithInfoNote(&_menu_user_blue_light,
+                                     (ListItem){
+                                         .label = "",
+                                         .disabled = !network_state.ntp,
+                                         .item_type = TOGGLE,
+                                         .value = (int)settings.blue_light_schedule,
+                                         .action = action_blueLightSchedule},
+                                     "Enable or disable the bluelight filter schedule\n");
+        }
         list_addItemWithInfoNote(&_menu_user_blue_light,
                                  (ListItem){
                                      .label = "Strength",
@@ -517,29 +522,35 @@ void menu_blueLight(void *_)
                                      .value = value_blueLightLevel()},
                                  "Change the strength of the \n"
                                  "Blue light filter");
-        list_addItemWithInfoNote(&_menu_user_blue_light,
-                                    (ListItem){
-                                        .label = "Time (On)",
-                                        .item_type = MULTIVALUE,
-                                        .value_max = 95,
-                                        .value_formatter = formatter_Time,
-                                        .action = action_blueLightTimeOn,
-                                        .value = value_blueLightTimeOn()},
-                                    "Time schedule for the bluelight filter");
-        list_addItemWithInfoNote(&_menu_user_blue_light,
-                                    (ListItem){
-                                        .label = "Time (Off)",
-                                        .item_type = MULTIVALUE,
-                                        .value_max = 95,
-                                        .value_formatter = formatter_Time,
-                                        .action = action_blueLightTimeOff,
-                                        .value = value_blueLightTimeOff()},
-                                    "Time schedule for the bluelight filter");
+        if (DEVICE_ID == MIYOO354) {
+            list_addItemWithInfoNote(&_menu_user_blue_light,
+                                     (ListItem){
+                                         .label = "Time (On)",
+                                         .disabled = !network_state.ntp,
+                                         .item_type = MULTIVALUE,
+                                         .value_max = 95,
+                                         .value_formatter = formatter_Time,
+                                         .action = action_blueLightTimeOn,
+                                         .value = value_blueLightTimeOn()},
+                                     "Time schedule for the bluelight filter");
+            list_addItemWithInfoNote(&_menu_user_blue_light,
+                                     (ListItem){
+                                         .label = "Time (Off)",
+                                         .disabled = !network_state.ntp,
+                                         .item_type = MULTIVALUE,
+                                         .value_max = 95,
+                                         .value_formatter = formatter_Time,
+                                         .action = action_blueLightTimeOff,
+                                         .value = value_blueLightTimeOff()},
+                                     "Time schedule for the bluelight filter");
+        }
     }
-    _writeDateString(_menu_user_blue_light.items[0].label);
-    char scheduleToggleLabel[100];
-    strcpy(scheduleToggleLabel, exists("/tmp/.blfIgnoreSchedule") ? "Schedule (ignored)" : "Schedule");
-    strcpy(_menu_user_blue_light.items[2].label, scheduleToggleLabel);
+    if (DEVICE_ID == MIYOO354) {
+        _writeDateString(_menu_user_blue_light.items[0].label);
+        char scheduleToggleLabel[100];
+        strcpy(scheduleToggleLabel, exists("/tmp/.blfIgnoreSchedule") ? "Schedule (ignored)" : "Schedule");
+        strcpy(_menu_user_blue_light.items[2].label, scheduleToggleLabel);
+    }
     menu_stack[++menu_level] = &_menu_user_blue_light;
     header_changed = true;
 }

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -60,7 +60,9 @@ main() {
     touch /tmp/no_charging_ui
 
     # Check if blf needs enabling
-    if [ -f $sysdir/config/.blfOn ]; then
+    if [ -f $sysdir/config/.blf ]; then
+        /mnt/SDCARD/.tmp_update/script/blue_light.sh check &
+    elif [ -f $sysdir/config/.blfOn ]; then
         /mnt/SDCARD/.tmp_update/script/blue_light.sh enable &
     fi
 

--- a/static/build/.tmp_update/script/blue_light.sh
+++ b/static/build/.tmp_update/script/blue_light.sh
@@ -68,35 +68,6 @@ set_intensity() {
     rm $lockfile
 }
 
-disable_blue_light_filter() {   
-    sync
-    
-    combinedBGR=$(cat $sysdir/config/display/blueLightRGB)
-    combinedBGR=$(echo "$combinedBGR" | tr -d '[:space:]/#')
-
-    echo $combinedBGR > $sysdir/config/display/blueLightRGBtemp
-
-    lastR=$(( (combinedBGR >> 16) & 0xFF ))
-    lastG=$(( (combinedBGR >> 8) & 0xFF ))
-    lastB=$(( combinedBGR & 0xFF ))
-    
-    # echo "Last BGR: B: $lastB, G: $lastG, R: $lastR"
-    # echo "Target BGR: B: 128, G: 128, R: 128"
-
-    for i in $(seq 0 20); do
-        newR=$(( lastR + (128 - lastR) * i / 20 ))
-        newG=$(( lastG + (128 - lastG) * i / 20 ))
-        newB=$(( lastB + (128 - lastB) * i / 20 ))
-
-        echo "colortemp 0 0 0 0 $newB $newG $newR" > /proc/mi_modules/mi_disp/mi_disp0
-        usleep 50000
-    done
-
-    echo ":: Blue Light Filter: Disabled"
-    rm -f $blf_key_on
-    rm -f $blf_key_on_user
-}
-
 check_disp_init() {
     if [ -z "$sysdir" ] || [ ! -x "$sysdir/bin/disp_init" ]; then
         echo "Error: disp_init not found or not executable"
@@ -192,7 +163,7 @@ disable_blue_light_filter() {
     
     echo ":: Blue Light Filter: Disabled"
     rm -f $blf_key_on
-    rm -f $sysdir/config/.blfOn
+    rm -f $blf_key_on_user
 }
 
 check_blf() {

--- a/static/build/.tmp_update/script/blue_light.sh
+++ b/static/build/.tmp_update/script/blue_light.sh
@@ -168,9 +168,10 @@ disable_blue_light_filter() {
 
 check_blf() {
     sync
-    if [ ! -f "$ignore_schedule" ]; then
-        if [ ! -f "$sysdir/config/.ntpState" ]; then
-            return
+    if [ -f "$blf_key" ] || [ ! -f "$ignore_schedule" ]; then
+
+        if [ ! -f "$blf_key_on" ] && [ -f "$blf_key_on_user" ]; then
+            rm -f $blf_key_on_user
         fi
         
         blueLightTimeOnFile="$sysdir/config/display/blueLightTime"
@@ -189,30 +190,24 @@ check_blf() {
         blueLightTimeOnMinutes=$(to_minutes_since_midnight "$blueLightTimeOn")
         blueLightTimeOffMinutes=$(to_minutes_since_midnight "$blueLightTimeOff")
 
-        if [ -f "$blf_key" ]; then
-            if [ "$blueLightTimeOffMinutes" -lt "$blueLightTimeOnMinutes" ]; then
-                if [ "$currentTimeMinutes" -ge "$blueLightTimeOnMinutes" ] || [ "$currentTimeMinutes" -lt "$blueLightTimeOffMinutes" ]; then
-                    if [ ! -f $blf_key_on ]; then
-                        enable_blue_light_filter 
-                        touch $blf_key_on
-                    fi
-                else
-                    if [ -f $blf_key_on ]; then
-                        disable_blue_light_filter 
-                        rm $blf_key_on
-                    fi
+        if [ "$blueLightTimeOffMinutes" -lt "$blueLightTimeOnMinutes" ]; then
+            if [ "$currentTimeMinutes" -ge "$blueLightTimeOnMinutes" ] || [ "$currentTimeMinutes" -lt "$blueLightTimeOffMinutes" ]; then
+                if [ ! -f $blf_key_on ]; then
+                    enable_blue_light_filter 
                 fi
             else
-                if [ "$currentTimeMinutes" -ge "$blueLightTimeOnMinutes" ] && [ "$currentTimeMinutes" -lt "$blueLightTimeOffMinutes" ]; then
-                    if [ ! -f $blf_key_on ]; then
-                        enable_blue_light_filter 
-                        touch $blf_key_on
-                    fi
-                else
-                    if [ -f $blf_key_on ]; then
-                        disable_blue_light_filter 
-                        rm $blf_key_on
-                    fi
+                if [ -f $blf_key_on ]; then
+                    disable_blue_light_filter 
+                fi
+            fi
+        else
+            if [ "$currentTimeMinutes" -ge "$blueLightTimeOnMinutes" ] && [ "$currentTimeMinutes" -lt "$blueLightTimeOffMinutes" ]; then
+                if [ ! -f $blf_key_on ]; then
+                    enable_blue_light_filter 
+                fi
+            else
+                if [ -f $blf_key_on ]; then
+                    disable_blue_light_filter 
                 fi
             fi
         fi

--- a/static/build/.tmp_update/script/blue_light.sh
+++ b/static/build/.tmp_update/script/blue_light.sh
@@ -168,7 +168,7 @@ disable_blue_light_filter() {
 
 check_blf() {
     sync
-    if [ -f "$blf_key" ] || [ ! -f "$ignore_schedule" ]; then
+    if [ -f "$blf_key" ] && [ ! -f "$ignore_schedule" ]; then
 
         if [ ! -f "$blf_key_on" ] && [ -f "$blf_key_on_user" ]; then
             rm -f $blf_key_on_user

--- a/website/docs/07-apps/01-included-in-onion/blue-light-filter.md
+++ b/website/docs/07-apps/01-included-in-onion/blue-light-filter.md
@@ -40,7 +40,7 @@ You'll find it in Tweaks app: [`Appearance` -› `Blue light filter...`](/docs/a
 5. **Time (Off)** - Time Blue light filter will be disabled
 
 :::note
-Schedule requires a Miyoo Mini Plus with "[Set time automatically via internet](/docs/apps/tweaks#set-automatically-via-the-internet)" enabled or a Miyoo Mini with RTC and .noTimeRestore (to prevent clock from overwriting the time) in order to function properly.
+To use Schedule you'll need a Miyoo Mini Plus with "[Set time automatically via internet](/docs/apps/tweaks#set-automatically-via-the-internet)" enabled.
 :::
 
 ### Hotkeys

--- a/website/docs/07-apps/01-included-in-onion/blue-light-filter.md
+++ b/website/docs/07-apps/01-included-in-onion/blue-light-filter.md
@@ -40,7 +40,7 @@ You'll find it in Tweaks app: [`Appearance` -› `Blue light filter...`](/docs/a
 5. **Time (Off)** - Time Blue light filter will be disabled
 
 :::note
-To use Schedule you'll need a Miyoo Mini Plus with "[Set time automatically via internet](/docs/apps/tweaks#set-automatically-via-the-internet)" enabled.
+To use Schedule you'll need a Miyoo Mini with RTC or a Miyoo Mini Plus with "[Set time automatically via internet](/docs/apps/tweaks#set-automatically-via-the-internet)" enabled.
 :::
 
 ### Hotkeys

--- a/website/docs/07-apps/01-included-in-onion/blue-light-filter.md
+++ b/website/docs/07-apps/01-included-in-onion/blue-light-filter.md
@@ -40,7 +40,7 @@ You'll find it in Tweaks app: [`Appearance` -› `Blue light filter...`](/docs/a
 5. **Time (Off)** - Time Blue light filter will be disabled
 
 :::note
-To use Schedule you'll need a Miyoo Mini with RTC or a Miyoo Mini Plus with "[Set time automatically via internet](/docs/apps/tweaks#set-automatically-via-the-internet)" enabled.
+To use Schedule you'll need a Miyoo Mini with RTC and .noTimeRestore set in config or a Miyoo Mini Plus with "[Set time automatically via internet](/docs/apps/tweaks#set-automatically-via-the-internet)" enabled.
 :::
 
 ### Hotkeys

--- a/website/docs/07-apps/01-included-in-onion/blue-light-filter.md
+++ b/website/docs/07-apps/01-included-in-onion/blue-light-filter.md
@@ -40,7 +40,7 @@ You'll find it in Tweaks app: [`Appearance` -› `Blue light filter...`](/docs/a
 5. **Time (Off)** - Time Blue light filter will be disabled
 
 :::note
-To use Schedule you'll need a Miyoo Mini Plus with "[Set time automatically via internet](/docs/apps/tweaks#set-automatically-via-the-internet)" enabled.
+Schedule requires a Miyoo Mini Plus with "[Set time automatically via internet](/docs/apps/tweaks#set-automatically-via-the-internet)" enabled or a Miyoo Mini with RTC and .noTimeRestore (to prevent clock from overwriting the time) in order to function properly.
 :::
 
 ### Hotkeys


### PR DESCRIPTION
- Enables the blue light schedule to work for the new Miyoo Mini V4 with RTC (or earlier revisions that have been modded).
- Prevent the blue light filter from always starting enabled on boot when the schedule says it should be off.
- Removed the network requirement, instead opting to blindly follow the current clock time if schedule is enabled.