### PR TITLE
GMU: Keep the music playing when turning off display

### DIFF
--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -260,15 +260,18 @@ void deepsleep(void)
 //
 void suspend_exec(int timeout)
 {
+    bool stay_awake = timeout == -1;
     keyinput_disable();
 
     // pause playActivity
     system("playActivity stop_all");
 
     // suspend
-    suspend(0);
+    if (!stay_awake) {
+        suspend(0);
+        setVolume(0);
+    }
     rumble(0);
-    setVolume(0);
     display_setBrightnessRaw(0);
     display_off();
     system_powersave_on();

--- a/static/packages/App/Music Player (GMU)/App/Gmu/launch.sh
+++ b/static/packages/App/Music Player (GMU)/App/Gmu/launch.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
-my_dir=`dirname $0`
+my_dir=$(dirname $0)
 cd $my_dir
 
 echo performance > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 . /mnt/SDCARD/.tmp_update/script/stop_audioserver.sh
+
+touch /tmp/stay_awake
 
 HOME=/mnt/SDCARD/App/Gmu
 LD_LIBRARY_PATH=/mnt/SDCARD/.tmp_update/lib/parasyte:./lib:$LD_LIBRARY_PATH
@@ -11,3 +13,4 @@ export LD_PRELOAD=./lib/libSDL-1.2.so.0
 ./gmu.bin -c gmu.miyoo.conf
 unset LD_PRELOAD
 
+rm -f /tmp/stay_awake


### PR DESCRIPTION
GMU will now keep playing music when the screen is off. And the system-wide sleep timer will be disabled when using GMU.

## Changes

- Added `stay_awake` flag when launching GMU
- Changed `keymon` to not suspend and mute when `stay_awake` is enabled

Closes #1717