### PR TITLE
Tweaks: Add toggle for the new OC hotkeys

### DIFF
--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -358,15 +358,18 @@ void turnOffScreen(void)
  */
 void cpuClockHotkey(int adjust)
 {
+    if (config_flag_get(".cpuClockHotkey") == 0) {
+        return;
+    }
     printf_debug("cpuClockHotkey: %d\n", adjust);
     int min_cpu_clock = 500; // ?
     int max_cpu_clock;
     switch (DEVICE_ID) {
     case MIYOO354:
-        max_cpu_clock = 1900;
+        max_cpu_clock = 1800;
         break;
     case MIYOO283:
-        max_cpu_clock = 1700;
+        max_cpu_clock = 1600;
         break;
     default:
         // Unknown device

--- a/src/tweaks/actions.h
+++ b/src/tweaks/actions.h
@@ -382,6 +382,11 @@ void action_advancedSetSwapTriggers(void *pt)
     stored_value_swap_triggers_changed = true;
 }
 
+void action_setCpuClockHotkey(void *pt)
+{
+    config_flag_set(".cpuClockHotkey", ((ListItem *)pt)->value);
+}
+
 void action_setAltBrightness(void *pt)
 {
     config_flag_set(".altBrightness", ((ListItem *)pt)->value);

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -710,7 +710,7 @@ void menu_diagnostics(void *pt)
 void menu_advanced(void *_)
 {
     if (!_menu_advanced._created) {
-        _menu_advanced = list_createWithTitle(7, LIST_SMALL, "Advanced");
+        _menu_advanced = list_createWithTitle(8, LIST_SMALL, "Advanced");
         list_addItemWithInfoNote(&_menu_advanced,
                                  (ListItem){
                                      .label = "Swap triggers (L<>L2, R<>R2)",
@@ -719,6 +719,14 @@ void menu_advanced(void *_)
                                      .action = action_advancedSetSwapTriggers},
                                  "Swap the function of L<>L2 and R<>R2\n"
                                  "(only affects in-game actions).");
+        list_addItemWithInfoNote(&_menu_advanced,
+                                 (ListItem){
+                                     .label = "OC hotkeys (SELECT+START+L/R)",
+                                     .item_type = TOGGLE,
+                                     .value = config_flag_get(".cpuClockHotkey"),
+                                     .action = action_setCpuClockHotkey},
+                                 "Enable the global hotkeys for\n"
+                                 "overclocking the CPU.");
         if (DEVICE_ID == MIYOO283) {
             list_addItemWithInfoNote(&_menu_advanced,
                                      (ListItem){

--- a/src/tweaks/menus.h
+++ b/src/tweaks/menus.h
@@ -711,6 +711,16 @@ void menu_advanced(void *_)
 {
     if (!_menu_advanced._created) {
         _menu_advanced = list_createWithTitle(8, LIST_SMALL, "Advanced");
+        if (exists(RESET_CONFIGS_PAK)) {
+            list_addItem(&_menu_advanced,
+                         (ListItem){
+                             .label = "Reset settings...",
+                             .action = menu_resetSettings});
+        }
+        list_addItem(&_menu_advanced,
+                     (ListItem){
+                         .label = "Diagnostics...",
+                         .action = menu_diagnostics});
         list_addItemWithInfoNote(&_menu_advanced,
                                  (ListItem){
                                      .label = "Swap triggers (L<>L2, R<>R2)",
@@ -771,16 +781,6 @@ void menu_advanced(void *_)
                                      "Use this option if you're seeing\n"
                                      "small artifacts on the display.");
         }
-        if (exists(RESET_CONFIGS_PAK)) {
-            list_addItem(&_menu_advanced,
-                         (ListItem){
-                             .label = "Reset settings...",
-                             .action = menu_resetSettings});
-        }
-        list_addItem(&_menu_advanced,
-                     (ListItem){
-                         .label = "Diagnostics...",
-                         .action = menu_diagnostics});
     }
     menu_stack[++menu_level] = &_menu_advanced;
     header_changed = true;


### PR DESCRIPTION
## Changes

- Add a toggle in **Tweaks -> Advanced** for enabling the global OC hotkeys (<kbd>SELECT</kbd>+<kbd>START</kbd>+<kbd>L</kbd>/<kbd>R</kbd>)
- Adjusted the max CPU from `1700/1900` to `1600/1800` due to user feedback (safe values)