### PR TITLE
GameSwitcher: Seamless State Management

### DIFF
--- a/src/common/system/display.h
+++ b/src/common/system/display.h
@@ -61,7 +61,14 @@ typedef struct Rect {
     int h;
 } rect_t;
 
-void display_reset()
+void display_clear(void)
+{
+    if (g_display.fb_addr) {
+        memset(g_display.fb_addr, 0, g_display.fb_size);
+    }
+}
+
+void display_reset(void)
 {
     if (fb_fd < 0)
         fb_fd = open("/dev/fb0", O_RDWR);
@@ -87,7 +94,7 @@ void display_getRenderResolution()
 //
 //    Get physical screen resolution
 //
-void display_getResolution()
+void display_getResolution(void)
 {
     FILE *file = fopen("/tmp/screen_resolution", "r");
     if (file == NULL) {

--- a/src/common/system/state.h
+++ b/src/common/system/state.h
@@ -422,6 +422,8 @@ void resumeGame(int index)
 
             file_put_sync(fp, CMD_TO_RUN_PATH, "%s", LaunchCommand);
 
+            temp_flag_set("force_auto_load_state", true);
+
             sync();
             return;
         }

--- a/src/common/system/system_utils.h
+++ b/src/common/system/system_utils.h
@@ -10,7 +10,7 @@
 //    [onion] Check retroarch running & savestate_auto_save in retroarch.cfg is
 //    true
 //
-int check_autosave(void)
+bool check_autosave(void)
 {
     char value[STR_MAX];
     file_parseKeyValue(RETROARCH_CONFIG, "savestate_auto_save", value, '=', 0);

--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -406,6 +406,11 @@ void cpuClockHotkey(int adjust)
     }
 }
 
+static void signal_refresh(int sig)
+{
+    display_getRenderResolution();
+}
+
 //
 //    Main
 //
@@ -414,7 +419,7 @@ int main(void)
     // Initialize
     signal(SIGTERM, quit);
     signal(SIGSEGV, quit);
-    signal(SIGUSR1, display_getRenderResolution);
+    signal(SIGUSR1, signal_refresh);
     log_setName("keymon");
 
     getDeviceModel();

--- a/src/keymon/menuButtonAction.h
+++ b/src/keymon/menuButtonAction.h
@@ -173,10 +173,15 @@ void action_MainUI_resumeGame(void)
 
 static void _saveAndQuitRetroArch(bool quickSwitch)
 {
-    enableSavingMessage();
-    retroarch_pause();
-    screenshot_system();
-    displaySavingMessage();
+    if (check_autosave()) {
+        enableSavingMessage();
+        retroarch_pause();
+        screenshot_system();
+        displaySavingMessage();
+    }
+    else {
+        display_clear();
+    }
     if (quickSwitch)
         set_quickSwitch();
     terminate_retroarch();
@@ -187,8 +192,8 @@ void action_RA_gameSwitcher(void)
     if (exists("/mnt/SDCARD/.tmp_update/.runGameSwitcher"))
         return;
     set_gameSwitcher();
-    system("(gameSwitcher --overlay && touch /tmp/state_changed) &");
     retroarch_pause();
+    system("(gameSwitcher --overlay && touch /tmp/state_changed) &");
     system_state_update();
 }
 

--- a/static/build/.tmp_update/script/game_list_options.sh
+++ b/static/build/.tmp_update/script/game_list_options.sh
@@ -340,8 +340,8 @@ get_json_value() {
 
 reset_game() {
     echo ":: reset_game $*"
-    echo -e "savestate_auto_load = \"false\"\nconfig_save_on_exit = \"false\"\n" > $sysdir/reset.cfg
-    echo "LD_PRELOAD=/mnt/SDCARD/miyoo/lib/libpadsp.so ./retroarch -v --appendconfig \"$sysdir/reset.cfg\" -L \"$corepath\" \"$rompath\"" > $sysdir/cmd_to_run.sh
+    echo -e "savestate_auto_load = \"false\"\nconfig_save_on_exit = \"false\"\n" > /tmp/reset.cfg
+    echo "LD_PRELOAD=/mnt/SDCARD/miyoo/lib/libpadsp.so ./retroarch -v --appendconfig \"/tmp/reset.cfg\" -L \"$corepath\" \"$rompath\"" > $sysdir/cmd_to_run.sh
     add_game_to_recent_list
     exit 0
 }


### PR DESCRIPTION
With this feature, you can enjoy the seamless game transitions provided by GameSwitcher even if you have disabled the "auto load state" option in RetroArch. This means you can switch between games effortlessly without being forced to enable the auto load state feature in RetroArch.

## Usage

- Disable the "auto load state" feature in RetroArch if you prefer not to use it.
- The auto save is not loaded when launching a game from the game list, search, or favorites.
- The auto save will still be loaded when you launch from GameSwitcher.
- Note: Quick switching will not create an auto save state.