### PR TITLE
Remove empty line from gpSP.cfg

### DIFF
--- a/static/configs/Saves/CurrentProfile/config/gpSP/gpSP.cfg
+++ b/static/configs/Saves/CurrentProfile/config/gpSP/gpSP.cfg
@@ -1,3 +1,2 @@
 aspect_ratio_index = "23"
 video_dingux_ipu_keep_aspect = "true"
-


### PR DESCRIPTION
Avoid an extraneous blank line when configuration directives are appended by scripts.