### PR TITLE
added warning text to not delete stock SD card as this bricks the process

### DIFF
--- a/website/docs/02-installation/01-fresh-install.mdx
+++ b/website/docs/02-installation/01-fresh-install.mdx
@@ -18,6 +18,10 @@ The SD card included with the Miyoo Mini is known to be slow, and will likely ru
 Stick to using SD cards from reputable brands (e.g. SanDisk or Samsung).
 :::
 
+:::caution Do not delte or format your stock SD card
+You will need to copy BIOS and ROMs from the stock SD card in step 3!
+:::
+
 ### Format your SD card as `FAT32` (not `exFAT`!)
 
 


### PR DESCRIPTION

when newbies delete the stock card and are not aware of, that they need the content - they are "bricked". This warning is to prevent this to happen.