### PR TITLE
Add .wsc to the Bandai WonderSwan docs page

### DIFF
--- a/website/docs/04-emulators/03-handhelds/02-bandai-wonderswan.md
+++ b/website/docs/04-emulators/03-handhelds/02-bandai-wonderswan.md
@@ -8,5 +8,5 @@ slug: /emulators/wonderswan
 
 - Emulator: **lr-mednafen-wswan**
 - Rom Folder: `WS`
-- Extensions: `.ws` `.pc2` `.zip` `.7z`
+- Extensions: `.ws` `.wsc` `.pc2` `.zip` `.7z`
 - Bios: None


### PR DESCRIPTION
The 'Bandai - WonderSwan / Color' page is missing the ``.wsc`` extension, which the emulator is able to play.