### PR TITLE
Fix: Ensure RetroArch saves are flushed before exiting via GameSwitcher

### DIFF
--- a/src/gameSwitcher/gs_overlay.h
+++ b/src/gameSwitcher/gs_overlay.h
@@ -145,9 +145,23 @@ void overlay_exit(void)
             pthread_join(autosave_thread_pt, NULL);
         }
 
-        // force kill retroarch
-        temp_flag_set(".forceKillRetroarch", true);
-        system("killall -9 retroarch");
+        // try graceful shutdown first
+        system("killall -TERM retroarch");
+
+        // wait up to 5 seconds for RetroArch to exit
+        for (int i = 0; i < 10; i++) {
+            msleep(500);  // 0.5s x 10 = 5s
+            if (system("pidof retroarch > /dev/null") != 0) {
+                break;  // retroarch is gone
+            }
+        }
+
+        // if still running, force kill
+        if (system("pidof retroarch > /dev/null") == 0) {
+            print_debug("RetroArch still running, force killing...");
+            temp_flag_set(".forceKillRetroarch", true);
+            system("killall -9 retroarch");
+        }
     }
 }
 


### PR DESCRIPTION
Replaces SIGKILL with a graceful SIGTERM followed by a 5-second wait before force-killing RetroArch if necessary. This change allows RetroArch to complete its content close process and write save files to disk, resolving issues where saves were lost when quitting with GameSwitcher.

Fixes #1815