### PR TITLE
Fix RTC desync when switching in/out of Guest Mode

### DIFF
--- a/static/packages/App/Guest Mode/App/Guest_Mode/launch.sh
+++ b/static/packages/App/Guest Mode/App/Guest_Mode/launch.sh
@@ -7,8 +7,10 @@ defautTheme="/mnt/SDCARD/Themes/Silky by DiMo/"
 progdir=`cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P`
 cd $progdir
 
-# Save current time
-./saveTime.sh
+if [ ! -f /tmp/rtc_available ]; then
+  # Save current time
+  ./saveTime.sh
+fi
 sync
 
 # Save current Favourites + RecentList lists
@@ -46,5 +48,7 @@ if [ -e "$currentThemefile" ]; then
 fi
 themeSwitcher --reapply_icons
 
-# Load current time
-./loadTime.sh
+if [ ! -f /tmp/rtc_available ]; then
+  # Load current time
+  ./loadTime.sh
+fi


### PR DESCRIPTION
This is a simple fix: Guest Mode now detects if the device has an RTC via the rtc_available flag set by runtime.sh on startup. If so, when switching profiles it skips saving and restoring the time to/from currentTime.txt.

Fixes #1852 