### PR TITLE
Website fix and typos

### DIFF
--- a/website/docs/01-features/index.md
+++ b/website/docs/01-features/index.md
@@ -248,7 +248,7 @@ MainUI is the main interface of Onion provided by Miyoo and modified by Onion Te
   <sup>Credit: Eggs</sup>
 - New default theme inspired by the Lilla theme by Evolve  
   <sup>Credit: DiMo</sup>
-- OnionOS icon by Evolve
+- Onion icon by Evolve
 - Textures are compressed for faster results  
   <sup>Credit: DiMo</sup>
 - Box art size fix in the included themes  

--- a/website/docs/01-features/index.md
+++ b/website/docs/01-features/index.md
@@ -137,7 +137,7 @@ It allows you to change the color temperature of the screen to have more eye com
 
 :::note <a href="apps/retroarch">RetroArch overview</a>
 A full **RetroArch** in a such tiny device! **RetroArch** is regularly updated from the official repository. Onion benefits from dedicated drivers created by [Eggs](https://discordapp.com/users/778867980096241715) for precision and performance.
-Dedicated customizations are also included: All the cores are configured with attention to detail, [custom overlays and custom filters](apps/retroarch#customized-overlays-and-filters) made specially for the Miyoo Mini screen. 
+Dedicated customizations are also included: All the cores are configured with attention to detail, [custom overlays and custom filters](apps/RetroArch#customized-overlays-and-filters) made specially for the Miyoo Mini screen. 
 :::
 
 ## <sup><img src={require('./assets/optimized.png').default} style={{width: 54}} /></sup>Optimized emulators
@@ -220,7 +220,7 @@ For the Miyoo Mini Plus (equipped with wifi) Onion offers many additional possib
 - [Easy Netplay](multiplayer/easynetplay): play multiplayer games anywhere (compatible with GB/GBC Pokemon trading!)
 - [OTA (Over The Air) updates](apps/ota-update): update Onion directly from your MMP
 - [Automatic date/time synchronisation](apps/tweaks#set-automatically-via-the-internet) (NTP, via Tweaks app)
-- [Retroachivements](https://www.retroarch.com/?page=achievements)
+- [RetroAchievements](https://www.retroarch.com/?page=achievements)
 - [Scraper](/docs/apps/scraper): import game covers directly from your MMP
 - [Network Services](network-features): [Samba/SMB share](network/samba), [http server](network/http), [SSH](network/ssh), [FTP](network/ftp), [Telnet](network/telnet), [Hotspot](network/hotspot), [VNC server](network/vnc)...
 :::

--- a/website/docs/01-features/index.md
+++ b/website/docs/01-features/index.md
@@ -215,7 +215,7 @@ Check the <a href="included-apps">included apps</a> documentation for more infor
 <img title="Included apps" src={require('./assets/network-features.gif').default} style={{width: 320}} />
 
 :::note <a href="network-features">Network Features</a>
-For the Miyoo Mini Plus (equipped with wifi) Onion offers many additional possibilities :<br />
+For the Miyoo Mini Plus (equipped with Wi-Fi) Onion offers many additional possibilities :<br />
 - [Multiplayer/Netplay](multiplayer): play in multiplayer over internet or on your local network to your favorite retro games:
 - [Easy Netplay](multiplayer/easynetplay): play multiplayer games anywhere (compatible with GB/GBC Pokemon trading!)
 - [OTA (Over The Air) updates](apps/ota-update): update Onion directly from your MMP

--- a/website/docs/01-features/index.md
+++ b/website/docs/01-features/index.md
@@ -44,7 +44,7 @@ description: Overview of the most important features
 <p align="center"><a href="./apps/shortcuts"><img src={require('../07-apps/01-included-in-onion/assets/shortcuts.webp').default} style={{width: 320}} /></a></p>
 
 :::note <a href="./apps/shortcuts">Shortcuts overview</a>
-The Onion **Shortcuts** are very powerful it allows you quick actions like rewind, fast forward, screenshots, volume boost... 
+The Onion **Shortcuts** are very powerful and allow you quick actions like rewind, fast forward, screenshots, volume boost... 
 :::
 
 
@@ -54,7 +54,7 @@ The Onion **Shortcuts** are very powerful it allows you quick actions like rewin
 
 
 :::note <a href="apps/game-switcher">Game Switcher overview</a>
-The **GameSwitcher** is designed to be the central user interface of Onion. It allows browse and resume the last games played in few seconds.
+The **GameSwitcher** is designed to be the central user interface of Onion. It allows you to browse and resume the last games played in few seconds.
 Launch the **GameSwitcher** by pressing the <kbd>MENU</kbd> button, then you'll see a screenshot of where you were in your game! Use <kbd>LEFT</kbd> and <kbd>RIGHT</kbd> to browse the last games played like this.
 It also allows you to quickly change games and many other features.
 :::
@@ -88,7 +88,7 @@ The **Package Manager** app is a powerful tool that allows users to easily insta
 
 :::note <a href="apps/search">Search overview</a>
 The **Search** application is the perfect companion for large game collections. It lets you find all the games containing the keyword you've entered.
-**Search** also allows to filter a game list to include only games containing a specific keyword.
+**Search** also allows you to filter a game list to include only games containing a specific keyword.
 :::
 
 
@@ -99,9 +99,9 @@ The **Search** application is the perfect companion for large game collections. 
 
 :::note <a href="apps/theme-switcher">Theme-switcher overview</a>
 Onion loves themes. Onion **Themes** allows you to customize the background, the entry categories, console icons, music background, fonts... And best of all, the chosen theme impacts all Onion's internal applications!<br />
-**Themes** in Onion are two things : <br /> 
+**Themes** in Onion are two things:<br /> 
 - [A fabulous theme repository](https://github.com/OnionUI/Themes/blob/main/README.md) with a very active participation from Onion community <sup><sub>❤️</sub></sup>
-- An application called <a href="apps/theme-switcher">Theme-switcher</a> included in Onion which allows to preview and change themes.
+- An application called <a href="apps/theme-switcher">Theme-switcher</a> included in Onion that allows you to preview and change themes.
 :::
 
 
@@ -119,7 +119,7 @@ Thanks to **Activity Tracker** app you can :
 ## <sup><img src={require('./assets/blue-light-filter.webp').default} style={{width: 54}} /></sup>Blue light filter
 
 :::note <a href="apps/blue-light-filter">Blue Light Filter</a>
-Thanks to **Blue Light Filter** feature from Tweaks app take care to your eyes!
+Thanks to the **Blue Light Filter** feature from Tweaks app, take care of your eyes!
 It allows you to change the color temperature of the screen to have more eye comfort in low-light environments.
 :::
 

--- a/website/docs/01-features/index.md
+++ b/website/docs/01-features/index.md
@@ -137,7 +137,7 @@ It allows you to change the color temperature of the screen to have more eye com
 
 :::note <a href="apps/retroarch">RetroArch overview</a>
 A full **RetroArch** in a such tiny device! **RetroArch** is regularly updated from the official repository. Onion benefits from dedicated drivers created by [Eggs](https://discordapp.com/users/778867980096241715) for precision and performance.
-Dedicated customizations are also included: All the cores are configured with attention to detail, [custom overlays and custom filters](apps/RetroArch#customized-overlays-and-filters) made specially for the Miyoo Mini screen. 
+Dedicated customizations are also included: All the cores are configured with attention to detail, [custom overlays and custom filters](apps/retroarch#customized-overlays-and-filters) made specially for the Miyoo Mini screen. 
 :::
 
 ## <sup><img src={require('./assets/optimized.png').default} style={{width: 54}} /></sup>Optimized emulators

--- a/website/docs/02-installation/01-fresh-install.mdx
+++ b/website/docs/02-installation/01-fresh-install.mdx
@@ -107,7 +107,7 @@ Chrome already has a tool to format an SD card. Insert the card into your Chrome
 </Tabs>
 
 :::note Installation files
-The Onion installation files consists of the following folders:
+The Onion installation files consist of the following folders:
 ```sh showLineNumbers
 .tmp_update/  # Might be hidden
 BIOS/

--- a/website/docs/02-installation/02-upgrading.mdx
+++ b/website/docs/02-installation/02-upgrading.mdx
@@ -61,13 +61,13 @@ please **make sure to create in-game saves** before upgrading.
 <TabItem value="chromeos" label="Chrome OS">
 
 :::tip Recommended method
-Due to limitations in the way the Chrome OS File Manager works, it's recommended to backup your personal files, perform a clean install of Onion OS on the SD card, and then restore your backed up files. The following instructions go through this procedure.
+Due to limitations in the way the Chrome OS File Manager works, it's recommended to backup your personal files, perform a clean install of Onion on the SD card, and then restore your backed up files. The following instructions go through this procedure.
 :::
 
 1. Display the contents of the SD card on the File Manager by double-clicking the drive icon.
 2. Backup your personal files such as the ones under `Roms`, `BIOS`, `Saves` and `Themes` directories.
 3. Perform a [clean install](/docs/installation/fresh) on the SD card.
-4. Restore your files on the newly installed Onion SD card. **Do not move a file to the same location as one with the same name**. This will cause the moved file to be duplicated with a number appended to it, and won't be recognized by Onion OS. 
+4. Restore your files on the newly installed Onion SD card. **Do not move a file to the same location as one with the same name**. This will cause the moved file to be duplicated with a number appended to it, and won't be recognized by Onion. 
 
 </TabItem>
 </Tabs>

--- a/website/docs/02-installation/02-upgrading.mdx
+++ b/website/docs/02-installation/02-upgrading.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 configs will carry over to the updated system.*
 
 :::note OTA UPDATES (MMP)
-The Miyoo Mini+ (Plus) can update Onion via the Wi-Fi connection using the OTA Update app. If the OTA update fails, simply follow the steps below to perform a manual update.
+The Miyoo Mini Plus (Plus) can update Onion via the Wi-Fi connection using the OTA Update app. If the OTA update fails, simply follow the steps below to perform a manual update.
 :::
 
 

--- a/website/docs/02-installation/02-upgrading.mdx
+++ b/website/docs/02-installation/02-upgrading.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 configs will carry over to the updated system.*
 
 :::note OTA UPDATES (MMP)
-The Miyoo Mini Plus (Plus) can update Onion via the Wi-Fi connection using the OTA Update app. If the OTA update fails, simply follow the steps below to perform a manual update.
+The Miyoo Mini Plus can update Onion via the Wi-Fi connection using the OTA Update app. If the OTA update fails, simply follow the steps below to perform a manual update.
 :::
 
 

--- a/website/docs/02-installation/index.mdx
+++ b/website/docs/02-installation/index.mdx
@@ -66,7 +66,7 @@ Firmware `2023 10 27 1401` and newer in conjunction with Onion 4.3 allow the MM 
 :::
 
 </TabItem>
-<TabItem value="mmp" label="Miyoo Mini+ (MMP)">
+<TabItem value="mmp" label="Miyoo Mini Plus (MMP)">
 
 
 3. You need at least firmware version `20230505****`, if you have an older version please download the recommended firmware linked below.

--- a/website/docs/02-installation/index.mdx
+++ b/website/docs/02-installation/index.mdx
@@ -93,7 +93,7 @@ Firmware `2023 10 27 1401` and newer in conjunction with Onion 4.3 allow the MM 
 ## <sup><img align="left" src="https://user-images.githubusercontent.com/44569252/179302769-4169e57a-860f-4c0e-8792-007e7557ba48.png" width="54" /></sup> Download the installation files
 
 :::info MMP support
-You need to install **Onion V4.2** for MMP, as earlier versions doesn't support the new hardware.
+You need to install **Onion V4.2** for MMP, as earlier versions don't support the new hardware.
 :::
 
 Download the latest version of Onion:

--- a/website/docs/03-faq/index.mdx
+++ b/website/docs/03-faq/index.mdx
@@ -118,7 +118,7 @@ Your first task is to find cheat files for your games (usually provided in `.cht
 1. Download the <IconLink href="https://github.com/libretro/libretro-database/archive/refs/heads/master.zip" icon="folder_zip">database repository as a ZIP file</IconLink>,
 2. Extract it and go into the `cht` directory (you will see cheats sorted by console),
 3. Copy directories for consoles you want to your Miyoo Mini's SD card, into the `RetroArch/.retroarch/cheats` directory (you might have to enable showing hidden directories if you can't see the `.retroarch` directory),
-4. Inside the `.retroarch` directory there will be a `retroarch.cfg` file, which you need to open in a text editor. Find the line with the option `quick_menu_show_cheats` and set it to `"true"` (so the whole line should be `quick_menu_show_cheats = "true"`),
+4. Inside the `.retroarch` directory there will be a `RetroArch.cfg` file, which you need to open in a text editor. Find the line with the option `quick_menu_show_cheats` and set it to `"true"` (so the whole line should be `quick_menu_show_cheats = "true"`),
 5. Eject your SD card from your computer and plug it into the Miyoo Mini, then open up your favourite game (for which you have downloaded cheats),
 6. Enter the RetroArch menu (press `Menu`, hold it, then press `Select`) and find the `Cheats › Load Cheat File (Replace)` option. There you can find the cheat file in one of the directories. After choosing it you will be returned back to the cheats menu, but now you should see a number of cheats at the bottom (e.g. `Cheat #0`),
 7. Select one of them, then toggle the `Enabled` switch to enable it.
@@ -388,7 +388,7 @@ In order to troubleshoot a particular game or emulator failure or issue, you may
 * Go to **Apps** › **RetroArch** › **Settings** › **Logging** and enable **Log to File**.  
 * Back out to the main RetroArch menu, and go to **Configuration File** and choose **Save Current Configuration**.  
 * Launch the game(s), or perform the action you are trying to troubleshoot.  
-* The output log file will be written to `.tmp_update/logs/retroarch.log`.  
+* The output log file will be written to `.tmp_update/logs/RetroArch.log`.  
 
 </details>
 
@@ -502,7 +502,7 @@ To manage your current Save State slot:
 > - Launch a game and press <kbd>MENU</kbd>+<kbd>SELECT</kbd> to go into the RetroArch `Quick Menu`
 > - Press <kbd>B</kbd> once, to go to RA `Main Menu`
 > - Go to `Settings` > `Saving` > `Increment Save State Index Automatically` (and toggle this off)
-> - Press <kbd>B</kbd> twice and go to `Quick Menu` > `Overrides` to [save the RA settings](#how-do-i-save-retroarch-settings)
+> - Press <kbd>B</kbd> twice and go to `Quick Menu` > `Overrides` to [save the RA settings](#how-do-i-save-RetroArch-settings)
 
 
 
@@ -676,9 +676,9 @@ After the boot, the first binary launched from the SD card by the firmware is th
 
 It is possible to overclock your device starting from Onion 4.2.0. The speed improvement can be up to 20% and is very noticeable. The current overclocking procedure is a manual process.
 
-To overclock Retroarch for all cores, create a `cpuclock.txt` text file in the main Retroarch folder (e.g. `Retroarch/cpuclock.txt`) containing just the 4-digit Mhz number of the desired overclock speed (e.g. `1600`).
+To overclock RetroArch for all cores, create a `cpuclock.txt` text file in the main RetroArch folder (e.g. `RetroArch/cpuclock.txt`) containing just the 4-digit Mhz number of the desired overclock speed (e.g. `1600`).
 
-To overclock just a specific Retroarch core, create the `cpuclock.txt` text file within that core's configuration folder in `Saves/CurrentProfile/config/<core>/`. For example, if you want to improve the PSX speed of PCSX-ReARMed (which will allow you to enable *enhanced resolution* for many additional games) you can create a `cpuclock.txt` file containing `1600` inside `Saves/CurrentProfile/config/PCSX-ReARMed/`.
+To overclock just a specific RetroArch core, create the `cpuclock.txt` text file within that core's configuration folder in `Saves/CurrentProfile/config/<core>/`. For example, if you want to improve the PSX speed of PCSX-ReARMed (which will allow you to enable *enhanced resolution* for many additional games) you can create a `cpuclock.txt` file containing `1600` inside `Saves/CurrentProfile/config/PCSX-ReARMed/`.
 
 The maximum device overclock speeds are:
 - Miyoo Mini: 1700Mhz (1600 recommended for optimal stability)

--- a/website/docs/03-faq/index.mdx
+++ b/website/docs/03-faq/index.mdx
@@ -388,7 +388,7 @@ In order to troubleshoot a particular game or emulator failure or issue, you may
 * Go to **Apps** › **RetroArch** › **Settings** › **Logging** and enable **Log to File**.  
 * Back out to the main RetroArch menu, and go to **Configuration File** and choose **Save Current Configuration**.  
 * Launch the game(s), or perform the action you are trying to troubleshoot.  
-* The output log file will be written to `.tmp_update/logs/RetroArch.log`.  
+* The output log file will be written to `.tmp_update/logs/retroarch.log`.  
 
 </details>
 

--- a/website/docs/03-faq/index.mdx
+++ b/website/docs/03-faq/index.mdx
@@ -54,7 +54,7 @@ For example:
 It will run Green pdf reader with the manual of the selected rom.
 
 :::note
-The *Game manual* option is not displayed in GLO menu if the pdf file doesn't exist or if it is not wall named (the files names are key sensitive).
+The *Game manual* option is not displayed in GLO menu if the pdf file doesn't exist or if it is not well named (file names are case sensitive).
 :::
 
 </details>

--- a/website/docs/03-faq/index.mdx
+++ b/website/docs/03-faq/index.mdx
@@ -228,7 +228,7 @@ To easily make bulk changes to your console or system names you can also use the
 Visit the [onionos-console-renamer github](https://github.com/Andrea922/onionos-console-renamer) to download and follow the instructions detailed there.  
 
 > Notes:  
-> Systems in Onion OS are displayed in alphabetical order so the name will determine where in your list it sits.   
+> Systems in Onion are displayed in alphabetical order so the name will determine where in your list it sits.   
 > An alternative method to order the systems is by adding an equal number of spaces both sides of the label name.  
 > The number of spaces determines the position it is displayed on the Mini, with the most spaces being first.  
 > For example, _“   Arcade   “_ will appear before _“Arcade”_. 
@@ -429,9 +429,9 @@ START + L2 / R2 Adjust volume boost ([see shortcuts](/docs/apps/shortcuts))
 
 </summary>
 
-You can copy in-game save files from another device or emulator for use in OnionOS. 
+You can copy in-game save files from another device or emulator for use in Onion. 
 * In most cases, Save files should be in `.srm` format, named identically to the rom and are case sensitive. Note that `.sav` files can be renamed to `.srm`, other formats may require a conversion tool. 
-* To add your saves to OnionOS just copy your individual save files into the correct emulator folder in: `Saves/CurrentProfile/saves/[CORENAME]`
+* To add your saves to Onion just copy your individual save files into the correct emulator folder in: `Saves/CurrentProfile/saves/[CORENAME]`
 * If you have already launched the game prior to adding your saves then you will also need to go to the `Saves/CurrentProfile/states/[CORENAME]` folder ...and delete any Save States here for the same game(s) in order for your newly added game saves to be recognised.
 
 > `[CORENAME]` = The folder with name of the RA core for the particular emulator or system the save file(s) relates to.     
@@ -661,7 +661,7 @@ Onion doesn't modify the firmware of your Miyoo Mini so this is not a CFW. It ca
 The way how your Miyoo Mini is booting will not change and it is a good thing because:
 - it avoids the risk of bad flash.
 - the original firmware of the Miyoo Mini starts up really fast !
-After the boot, the first binary launched from the SD card by the firmware is the Onion scripts directly, making the boot of Onion OS fast and safe.
+After the boot, the first binary launched from the SD card by the firmware is the Onion scripts directly, making the boot of Onion fast and safe.
 
 > Notes:  
 > The community is working on [a real alternative firmware](https://github.com/orgs/miyoo-oss/repositories). It's currently not usable with Onion. The objective is to obtain a better control of the hardware part and a more recent linux kernel which could simplify the compilation of additional apps.

--- a/website/docs/03-faq/index.mdx
+++ b/website/docs/03-faq/index.mdx
@@ -118,7 +118,7 @@ Your first task is to find cheat files for your games (usually provided in `.cht
 1. Download the <IconLink href="https://github.com/libretro/libretro-database/archive/refs/heads/master.zip" icon="folder_zip">database repository as a ZIP file</IconLink>,
 2. Extract it and go into the `cht` directory (you will see cheats sorted by console),
 3. Copy directories for consoles you want to your Miyoo Mini's SD card, into the `RetroArch/.retroarch/cheats` directory (you might have to enable showing hidden directories if you can't see the `.retroarch` directory),
-4. Inside the `.retroarch` directory there will be a `RetroArch.cfg` file, which you need to open in a text editor. Find the line with the option `quick_menu_show_cheats` and set it to `"true"` (so the whole line should be `quick_menu_show_cheats = "true"`),
+4. Inside the `.retroarch` directory there will be a `retroarch.cfg` file, which you need to open in a text editor. Find the line with the option `quick_menu_show_cheats` and set it to `"true"` (so the whole line should be `quick_menu_show_cheats = "true"`),
 5. Eject your SD card from your computer and plug it into the Miyoo Mini, then open up your favourite game (for which you have downloaded cheats),
 6. Enter the RetroArch menu (press `Menu`, hold it, then press `Select`) and find the `Cheats › Load Cheat File (Replace)` option. There you can find the cheat file in one of the directories. After choosing it you will be returned back to the cheats menu, but now you should see a number of cheats at the bottom (e.g. `Cheat #0`),
 7. Select one of them, then toggle the `Enabled` switch to enable it.

--- a/website/docs/04-emulators/01-arcade/01-arcade-default.md
+++ b/website/docs/04-emulators/01-arcade/01-arcade-default.md
@@ -15,7 +15,7 @@ slug: /emulators/arcade/default
 - Required rom set version: `MAME 2003-Plus Reference: Full Non-Merged Romsets`
 - Samples: Audio Samples for Mame2003Plus should be placed in the `/BIOS/mame2003-plus/samples` folder
  
-MAME does not play well with save states this is a core issue and cannot be fixed. It is recommended to disable 'auto-loading of save states' in the Retroarch menu (and save core overrides).
+MAME does not play well with save states this is a core issue and cannot be fixed. It is recommended to disable 'auto-loading of save states' in the RetroArch menu (and save core overrides).
 
 An onscreen message saying ‘This Game Will Not Work’ is MAME letting you know that the game is not emulated in the MAME version and you will not find a compatible/playable rom for that game.
 

--- a/website/docs/04-emulators/01-arcade/index.mdx
+++ b/website/docs/04-emulators/01-arcade/index.mdx
@@ -15,7 +15,7 @@ While MAME supports many classic arcade games, for best compatibility and perfor
 
 Both MAME and FB require your romsets to be matched exactly to the emulator version so you will need to source the recommended romsets. MAME romsets are not compatible with FB cores (and vice versa) and not every game in a full romset will be playable but the majority will be.  
 
-Arcade roms in general do not play well with save states (some will work but the majority don’t), you can [disable auto-loading of save states](../faq#how-do-i-disable-auto-load-save-states) in the Retroarch menu (and save content or core overrides).  
+Arcade roms in general do not play well with save states (some will work but the majority don’t), you can [disable auto-loading of save states](../faq#how-do-i-disable-auto-load-save-states) in the RetroArch menu (and save content or core overrides).  
 
 MAME and FB both rely on internal databases to translate the rom file name into the displayed game name, some games may be missing from the db. You should never rename these roms, instead you can use the [miyoogamelist](../faq#how-can-i-use-a-miyoogamelistxml-to-customize-game-names) functionality to give your arcade roms appropriate names.   
 

--- a/website/docs/04-emulators/02-consoles/10-commodore-amiga.md
+++ b/website/docs/04-emulators/02-consoles/10-commodore-amiga.md
@@ -18,7 +18,7 @@ See [this link](https://docs.libretro.com/library/puae/) for more information.
 
 - <kbd>SELECT</kbd> toggles the onscreen keyboard, <kbd>L</kbd> & <kbd>R</kbd> are mapped to the mouse buttons.
 - This emulator will play Amiga CD32 games though some perform better than others.
-- Setting CPU speed to -700 (negative 700) in the Retroarch menu may improve A1200/CD32 performance.
+- Setting CPU speed to -700 (negative 700) in the RetroArch menu may improve A1200/CD32 performance.
 - Other Core Settings that might be useful for some games are frameskip set to 1, or setting off the blitter wait in Video options.
 - Some games will have stuttering audio or behave very slowly regardless of the CPU speed, frameskip etc. Many of these games will work fine if you find another format for them. .hdf (hard disk files) are the most problematic. .adf or .lha games usually work better although you might have to open RA options to switch or add floppy disks when required. If you find a game that won't run correctly no matter the options you set for it, simply try to find another version in another format.
 

--- a/website/docs/04-emulators/02-consoles/35-snk-neo-geo.md
+++ b/website/docs/04-emulators/02-consoles/35-snk-neo-geo.md
@@ -24,7 +24,7 @@ https://www.youtube.com/watch?v=CGKX6yPG2nE
 ## Notes on GnGeo
 
 The GnGeo is an AES/MVS Neo Geo emulator (without NG-CD support) based of MAME ROMsets.
-This emulator is a standalone emulator (not Retroarch core) which natively supports GNO files.
+This emulator is a standalone emulator (not RetroArch core) which natively supports GNO files.
 GnGeo is interesting because of loading times. Tested a few big games like kof2000 and it starts just a few seconds instead of 45 seconds. The framerate is also very good.
 
 Interesting information about GnGeo [here](https://github.com/TriForceX/MiyooCFW/discussions/369) (with compatibility list).

--- a/website/docs/04-emulators/04-add-ons/02-dreamcast-vmu.md
+++ b/website/docs/04-emulators/04-add-ons/02-dreamcast-vmu.md
@@ -6,6 +6,6 @@
 - Extensions: `.vms` `.bin`
 - Bios: None
 
-A pixelated screen displays on launch. Open Retroarch (<kbd>MENU</kbd>+<kbd>SELECT</kbd>) and choose `Close Content`. Now select `History` and load the game file you just closed. Choose Run. The game should now display correctly but plays too fast. To fix this go back into Retroarch and set `Automatic Frame Delay` to ON in the Latency Menu.
+A pixelated screen displays on launch. Open RetroArch (<kbd>MENU</kbd>+<kbd>SELECT</kbd>) and choose `Close Content`. Now select `History` and load the game file you just closed. Choose Run. The game should now display correctly but plays too fast. To fix this go back into RetroArch and set `Automatic Frame Delay` to ON in the Latency Menu.
 
 <sup>(Credit: dwmccoy)</sup>

--- a/website/docs/04-emulators/05-miscellaneous/04-chailove.md
+++ b/website/docs/04-emulators/05-miscellaneous/04-chailove.md
@@ -12,7 +12,7 @@ slug: /emulators/chailove
 - Bios: None
 
 
-Like Pico-8, Lowres NX, MicroW8 or LÖVE, [ChaiLove](https://docs.libretro.com/library/chailove/) is a framework for making 2D games. This Retroarch core, inspired by LÖVE engine, uses the ChaiScript scripting language. 
+Like Pico-8, Lowres NX, MicroW8 or LÖVE, [ChaiLove](https://docs.libretro.com/library/chailove/) is a framework for making 2D games. This RetroArch core, inspired by LÖVE engine, uses the ChaiScript scripting language. 
 
 However the compatibility concerns to [a short list of Löve games](https://buildbot.libretro.com/assets/cores/ChaiLove/) (less than 10 games).
 

--- a/website/docs/04-emulators/05-miscellaneous/06-lowres-nx.md
+++ b/website/docs/04-emulators/05-miscellaneous/06-lowres-nx.md
@@ -13,6 +13,6 @@ slug: /emulators/lowresnx
 
 
 Like Pico-8, Chailove, MicroW8 or LÖVE, [LowRes NX](https://lowresnx.inutilis.com/) is a framework for making 2D games. 
-This Retroarch core uses the BASIC language to allow you to create your own retro games on a virtual game console.
+This RetroArch core uses the BASIC language to allow you to create your own retro games on a virtual game console.
 
 You can discover [a lot of their games here](https://lowresnx.inutilis.com/programs.php?category=featured).

--- a/website/docs/04-emulators/05-miscellaneous/07-lutro.md
+++ b/website/docs/04-emulators/05-miscellaneous/07-lutro.md
@@ -12,6 +12,6 @@ slug: /emulators/lutro
 - Bios: None
 
 
-Like Pico-8, Chailove, MicroW8 or LowRes NX, [Lutro](https://lutro.libretro.com/) is a framework for making 2D games. This Retroarch core uses the LÖVE API to allow you to create your own retro games on a virtual game console.
+Like Pico-8, Chailove, MicroW8 or LowRes NX, [Lutro](https://lutro.libretro.com/) is a framework for making 2D games. This RetroArch core uses the LÖVE API to allow you to create your own retro games on a virtual game console.
 
 However the compatibility is concerning to [a short list of Löve games](https://buildbot.libretro.com/assets/cores/Lutro/).

--- a/website/docs/04-emulators/05-miscellaneous/12-puzzlescript.md
+++ b/website/docs/04-emulators/05-miscellaneous/12-puzzlescript.md
@@ -13,7 +13,7 @@ slug: /emulators/puzzlescript
 - Bios: None
 
 
-Like Pico-8, Lowres NX, MicroW8 or LÖVE, [PuzzleScript](https://www.puzzlescript.net/) is a framework for making 2D games. This Retroarch core uses the HTML5 language to allow you to create your own retro puzzles games. 
+Like Pico-8, Lowres NX, MicroW8 or LÖVE, [PuzzleScript](https://www.puzzlescript.net/) is a framework for making 2D games. This RetroArch core uses the HTML5 language to allow you to create your own retro puzzles games. 
 
 All games are free an open source. 
 They have [an official game list here](https://www.puzzlescript.net/Gallery/index.html) but has also a real community which create many puzzles so you can find other games [here](https://philschatz.com/puzzlescript/) and on other places over the web! 

--- a/website/docs/04-emulators/05-miscellaneous/15-superbroswar.md
+++ b/website/docs/04-emulators/05-miscellaneous/15-superbroswar.md
@@ -17,7 +17,7 @@ slug: /emulators/superbroswar
 
 
 Super Mario War / Super Cat Wars is a fan-made multiplayer Super Mario Bros. Very customizable with many mods.
-Onion includes the Retroarch core. The standalone version (which includes the multiplayer mode) will be distributed as a port in the Onion Ports repository.
+Onion includes the RetroArch core. The standalone version (which includes the multiplayer mode) will be distributed as a port in the Onion Ports repository.
 The RetroArch core version allows you to fight against enemies controlled by the computer.
 
 ## 2 main assets:

--- a/website/docs/05-ports-collection/index.md
+++ b/website/docs/05-ports-collection/index.md
@@ -207,11 +207,11 @@ Please always use one of these 3 scripts as a template to add your own port.
  * `running command line`: Do not modify this (it is standardized)   
 
 
-**Specific to retroarch script :**
+**Specific to RetroArch script :**
 
  * `Core`: the name of the core that will be used without `_libretro.so`, for example `ecwolf` for Wolfenstein  
  * `RomDir`: similar to `GameDir` : it is the path where your rom is located in `Roms/PORTS/Games/[Game folder]/`  
- * `RomFile`: it is the name of the rom that will be passed as a parameter to the retroarch core, will be also used to detect the presence of the game when running `~Import ports` script from the rom list. (the `Core` will be used for detection if not specified) 
+ * `RomFile`: it is the name of the rom that will be passed as a parameter to the RetroArch core, will be also used to detect the presence of the game when running `~Import ports` script from the rom list. (the `Core` will be used for detection if not specified) 
 
 
 > **Notes about the `~Import ports` script :**  

--- a/website/docs/05-ports-collection/index.md
+++ b/website/docs/05-ports-collection/index.md
@@ -169,7 +169,7 @@ To install these you just have to extract the contents of the archive to the roo
 1. Rename your existing "Roms/PORTS" folder into something like Roms/PORTS_OLD  
 2. Update Onion to version 4.1.0 or later (the latest release is recommended) (see [upgrade guide](installation#upgrading-from-stock-or-onion))  
 3. Enable "Ports Collection" in `Apps` › `Package Manager` › `Verified`  
-4. Download the "the full Ports-Collection" from [the official repository](https://github.com/OnionUI/Ports-Collection) (first link in the description)  
+4. Download the full Ports-Collection from [the official repository](https://github.com/OnionUI/Ports-Collection) (first link in the description)  
 5. Extract the archive to the root of your SD card  
 6. Manually populate each `Roms/PORTS/Games/[Game folder]/` with your old assets, as detailed in the `_required_files.txt` file for each  
 7. We have pre-configured many things, so during your copy paste of your assets, do not overwrite the existing files  
@@ -209,7 +209,7 @@ Please always use one of these 3 scripts as a template to add your own port.
 
 **Specific to retroarch script :**
 
- * `Core`: then name of the core that will be used without `_libretro.so`, for example `ecwolf` for Wolfenstein  
+ * `Core`: the name of the core that will be used without `_libretro.so`, for example `ecwolf` for Wolfenstein  
  * `RomDir`: similar to `GameDir` : it is the path where your rom is located in `Roms/PORTS/Games/[Game folder]/`  
  * `RomFile`: it is the name of the rom that will be passed as a parameter to the retroarch core, will be also used to detect the presence of the game when running `~Import ports` script from the rom list. (the `Core` will be used for detection if not specified) 
 

--- a/website/docs/06-multiplayer-netplay/01-standardnetplay.md
+++ b/website/docs/06-multiplayer-netplay/01-standardnetplay.md
@@ -35,7 +35,7 @@ Each game you'll create will be available over internet and your local network, 
 
 2. Press <kbd>Y</kbd> to open GLO
 
-3. Choose `Netplay` -> `Host a session...` -> `Standard Netplay (use current wifi)`
+3. Choose `Netplay` -> `Host a session...` -> `Standard Netplay (use current Wi-Fi)`
  
 Your Onion netplay session is now ready to be joined from your local home network or even on the other side of the world.
 
@@ -46,7 +46,7 @@ Your Onion netplay session is now ready to be joined from your local home networ
 
 2. Press <kbd>Y</kbd> to open GLO
 
-3. Choose `Netplay` -> `Join a session...` -> `Standard Netplay (use current wifi)`
+3. Choose `Netplay` -> `Join a session...` -> `Standard Netplay (use current Wi-Fi)`
 
 4. Press Menu + Select to display the RetroArch menu, go into Netplay and then click on :
 	- `Refresh Netplay Host List` -> to display hosted games over internet

--- a/website/docs/06-multiplayer-netplay/01-standardnetplay.md
+++ b/website/docs/06-multiplayer-netplay/01-standardnetplay.md
@@ -9,7 +9,7 @@ slug: /multiplayer/standardnetplay
 
 *Fight against your friends remotely!*
 
-**Standard Netplay:** a feature to create and join Retroarch multiplayer sessions easily.
+**Standard Netplay:** a feature to create and join RetroArch multiplayer sessions easily.
 
 Each game you'll create will be available over internet and your local network, making it easy for your friends to join in your game.
 
@@ -19,7 +19,7 @@ Each game you'll create will be available over internet and your local network, 
 
 - Easy host setup
 
-- Optimized Retroarch configuration
+- Optimized RetroArch configuration
 
 - Automatic core selection for Netplay
 
@@ -48,7 +48,7 @@ Your Onion netplay session is now ready to be joined from your local home networ
 
 3. Choose `Netplay` -> `Join a session...` -> `Standard Netplay (use current wifi)`
 
-4. Press Menu + Select to display the retroarch menu, go into Netplay and then click on :
+4. Press Menu + Select to display the RetroArch menu, go into Netplay and then click on :
 	- `Refresh Netplay Host List` -> to display hosted games over internet
 	- `Refresh Netplay Lan List` -> to display hosted games over your local network
 	

--- a/website/docs/06-multiplayer-netplay/02-easynetplay.md
+++ b/website/docs/06-multiplayer-netplay/02-easynetplay.md
@@ -10,7 +10,7 @@ slug: /multiplayer/easynetplay
 
 *Fight against your friends or fight alongside them, the easy way!*
 
-**Easy Netplay:** a feature for convenience that streamlines multiplayer gaming: play from anywhere with all nearby Miyoo Mini Plus without any wifi or Retroarch configuration.
+**Easy Netplay:** a feature for convenience that streamlines multiplayer gaming: play from anywhere with all nearby Miyoo Mini Plus without any wifi or RetroArch configuration.
 
 This tool effortlessly sets up a hotspot, launches RetroArch and enables Netplay on the host side. On the client side, it joins the hotspot, checks the core and ROM checksums and connects to the RetroArch session, ensuring a seamless and enjoyable multiplayer experience.
 

--- a/website/docs/06-multiplayer-netplay/02-easynetplay.md
+++ b/website/docs/06-multiplayer-netplay/02-easynetplay.md
@@ -10,7 +10,7 @@ slug: /multiplayer/easynetplay
 
 *Fight against your friends or fight alongside them, the easy way!*
 
-**Easy Netplay:** a feature for convenience that streamlines multiplayer gaming: play from anywhere with all nearby Miyoo Mini Plus without any wifi or RetroArch configuration.
+**Easy Netplay:** a feature for convenience that streamlines multiplayer gaming: play from anywhere with all nearby Miyoo Mini Plus without any Wi-Fi or RetroArch configuration.
 
 This tool effortlessly sets up a hotspot, launches RetroArch and enables Netplay on the host side. On the client side, it joins the hotspot, checks the core and ROM checksums and connects to the RetroArch session, ensuring a seamless and enjoyable multiplayer experience.
 

--- a/website/docs/06-multiplayer-netplay/index.mdx
+++ b/website/docs/06-multiplayer-netplay/index.mdx
@@ -55,11 +55,11 @@ If "No Netplay" is displayed in GLO menu, it means that there are no Netplay-com
 
 - **[Standard Netplay](multiplayer/standardnetplay)**
  
-  This mode uses your current wifi connection to create an online session and on your local network.
+  This mode uses your current Wi-Fi connection to create an online session and on your local network.
 
 - **[Easy Netplay](multiplayer/easynetplay)**
  	
-  When you have two Miyoo Mini Plus in the same room, "Easy Netplay" lets you play a multiplayer game without any configuration, as it requires no prior wifi setup.
+  When you have two Miyoo Mini Plus in the same room, "Easy Netplay" lets you play a multiplayer game without any configuration, as it requires no prior Wi-Fi setup.
 
 - **[Easy Netplay - Pokemon Trade/Battle](multiplayer/easynetplay-pokemon)**
  	

--- a/website/docs/06-multiplayer-netplay/index.mdx
+++ b/website/docs/06-multiplayer-netplay/index.mdx
@@ -63,7 +63,7 @@ If "No Netplay" is displayed in GLO menu, it means that there are no Netplay-com
 
 - **[Easy Netplay - Pokemon Trade/Battle](multiplayer/easynetplay-pokemon)**
  	
-  This option in only available on GB/GBC, similar to the previous "Easy Netplay" but allows to trade pokemon with local friends without any configuration
+  This option is only available on GB/GBC, similar to the previous "Easy Netplay" but allows you to trade pokemon with local friends without any configuration
 
 
 

--- a/website/docs/06-multiplayer-netplay/index.mdx
+++ b/website/docs/06-multiplayer-netplay/index.mdx
@@ -63,7 +63,7 @@ If "No Netplay" is displayed in GLO menu, it means that there are no Netplay-com
 
 - **[Easy Netplay - Pokemon Trade/Battle](multiplayer/easynetplay-pokemon)**
  	
-  This option is only available on GB/GBC, similar to the previous "Easy Netplay" but allows you to trade pokemon with local friends without any configuration
+  This option is only available on GB/GBC, similar to the previous "Easy Netplay" but allows you to trade Pokemon with local friends without any configuration
 
 
 

--- a/website/docs/07-apps/01-included-in-onion/clock.md
+++ b/website/docs/07-apps/01-included-in-onion/clock.md
@@ -9,7 +9,7 @@ description: Set your Onion's time
 ## Presentation
 
 Simple clock app which allows you to manually set the clock of your device. Especially useful for the Miyoo Mini which doesn't have an internal RTC (which means that the time is reset at each boot). By default, Onion preserves the current time during shutdown, and upon the subsequent boot, it is restored with 4 hours added.
-If RTC is present, which is the case with newer Miyoo Mini+, or if it is modded in, the time is not restored or advanced but will instead be set by RTC.
+If RTC is present, which is the case with newer Miyoo Mini Plus, or if it is modded in, the time is not restored or advanced but will instead be set by RTC.
 
 ![](./assets/clock.png)
 

--- a/website/docs/07-apps/01-included-in-onion/game-list-options.md
+++ b/website/docs/07-apps/01-included-in-onion/game-list-options.md
@@ -29,7 +29,7 @@ GLO Menu is a native application of Onion, it is installed by default.
 ### Scripts available in Onion
 
 - **Reset game**: *load game without save state, useful to start a game from beginning*
-- **Game core**: *set custom Retroarch core per game, useful to switch from mGBA to gPSP for example*
+- **Game core**: *set custom RetroArch core per game, useful to switch from mGBA to gPSP for example*
 - **Filter list**: *use a keyword to filter the list*
 - **Refresh roms**: *refresh the list’s game cache, useful when you have added some games*
 - *Custom scripts:*

--- a/website/docs/07-apps/01-included-in-onion/ota-update.md
+++ b/website/docs/07-apps/01-included-in-onion/ota-update.md
@@ -17,7 +17,7 @@ Allows you to select stable or beta channel.
 
 ## Usage
 
-Onion OTA update is available in [Package Manager](package-manager). It will work only with WiFi/Miyoo Mini+.
+Onion OTA update is available in [Package Manager](package-manager). It will work only with WiFi/Miyoo Mini Plus.
 
 Once installed run it from Apps section.
 

--- a/website/docs/07-apps/01-included-in-onion/retroarch.md
+++ b/website/docs/07-apps/01-included-in-onion/retroarch.md
@@ -23,7 +23,7 @@ A full RetroArch in a such tiny device! RetroArch is regularly updated from the 
 - Customs cores
 - Fine-tuned with optimal best settings for the Miyoo Mini in mind
 - Automatically choosing the best resolution for your device
-  - 640x480 for the Miyoo Mini v1-3 and the Miyoo Mini+
+  - 640x480 for the Miyoo Mini v1-3 and the Miyoo Mini Plus
   - 752x560 for the Miyoo Mini v4 with firmware >= `202310271401`
 - Can also work as a game launcher  
   > Cores embedded, playlists and favorites unlocked

--- a/website/docs/07-apps/01-included-in-onion/retroarch.md
+++ b/website/docs/07-apps/01-included-in-onion/retroarch.md
@@ -1,5 +1,5 @@
 ---
-slug: /apps/retroarch
+slug: /apps/RetroArch
 ---
 
 # RetroArch

--- a/website/docs/07-apps/01-included-in-onion/retroarch.md
+++ b/website/docs/07-apps/01-included-in-onion/retroarch.md
@@ -1,5 +1,5 @@
 ---
-slug: /apps/RetroArch
+slug: /apps/retroarch
 ---
 
 # RetroArch

--- a/website/docs/07-apps/01-included-in-onion/scraper.md
+++ b/website/docs/07-apps/01-included-in-onion/scraper.md
@@ -6,7 +6,7 @@ description: Download your box arts using WiFi
 # Scraper
 
 A missing illustration in your game list? Onion Scraper can solve that!
-Using WiFi (so Miyoo Mini+ only), this app allows you to download game covers without even touching your SD card or a computer.  
+Using WiFi (so Miyoo Mini Plus only), this app allows you to download game covers without even touching your SD card or a computer.  
 
 https://www.youtube.com/watch?v=lOMP0ozb0I0
 

--- a/website/docs/07-apps/01-included-in-onion/tweaks.mdx
+++ b/website/docs/07-apps/01-included-in-onion/tweaks.mdx
@@ -65,7 +65,7 @@ Tweaks is the backbone of Onion's configuration and personalization! With Tweaks
 </summary>
 <div>With this option you can choose which frontend you want to launch into on startup.
 
-It can be MainUI, [GameSwitcher](./game-switcher), [RetroArch](./RetroArch) or [AdvanceMenu](./advancemenu).
+It can be MainUI, [GameSwitcher](./game-switcher), [RetroArch](./retroarch) or [AdvanceMenu](./advancemenu).
 </div>
 </details>
 <details><summary>

--- a/website/docs/07-apps/01-included-in-onion/tweaks.mdx
+++ b/website/docs/07-apps/01-included-in-onion/tweaks.mdx
@@ -65,7 +65,7 @@ Tweaks is the backbone of Onion's configuration and personalization! With Tweaks
 </summary>
 <div>With this option you can choose which frontend you want to launch into on startup.
 
-It can be MainUI, [GameSwitcher](./game-switcher), [Retroarch](./retroarch) or [AdvanceMenu](./advancemenu).
+It can be MainUI, [GameSwitcher](./game-switcher), [RetroArch](./RetroArch) or [AdvanceMenu](./advancemenu).
 </div>
 </details>
 <details><summary>

--- a/website/docs/07-apps/02-community-apps/index.mdx
+++ b/website/docs/07-apps/02-community-apps/index.mdx
@@ -15,22 +15,22 @@ Here you will find a selection of third party applications and tools compatible 
 <DocCardList />
 
 
-## Miyoo Mini+ only (WiFi required)
+## Miyoo Mini Plus only (WiFi required)
 
 1. [**Better WiFi Tools**](https://github.com/XK9274/better-wifi-miyoo) by XK9274  
    *Better WiFi management for the MMP (Onion)*
 
 2. [**Cloud Saves**](https://github.com/hotcereal/cloud-saves-miyoo-mini-plus) by hotcereal  
-   *Utilizing rclone, upload and download saves to and from your Miyoo Mini+*
+   *Utilizing rclone, upload and download saves to and from your Miyoo Mini Plus*
 
 3. [**Screen Capture Toolkit**](https://github.com/XK9274/screencap-toolkit-miyoo) by XK9274  
-   *A Screencapturing toolkit for the Miyoo Mini+ (Twitch/VNC/RTMP/Outputfile)*
+   *A Screencapturing toolkit for the Miyoo Mini Plus (Twitch/VNC/RTMP/Outputfile)*
 
 4. [**Speed Test**](https://github.com/josegonzalez/miyoo-speedtest) by josegonzalez  
-   *An app to allow testing internet speed on the Miyoo Mini+*
+   *An app to allow testing internet speed on the Miyoo Mini Plus*
 
 5. [**Spotify Client**](https://github.com/XK9274/ncspotcli-compile-miyoo) by XK9274  
-   *Builds ncspot for the Miyoo Mini+ (contains appfolder)*
+   *Builds ncspot for the Miyoo Mini Plus (contains appfolder)*
 
 6. [**syncthing**](https://github.com/XK9274/syncthing-app-miyoo) by XK9274  
    *Sets up Syncthing and injects into Onion 4.2.0 beta runtime.sh*

--- a/website/docs/07-apps/02-community-apps/index.mdx
+++ b/website/docs/07-apps/02-community-apps/index.mdx
@@ -18,7 +18,7 @@ Here you will find a selection of third party applications and tools compatible 
 ## Miyoo Mini+ only (WiFi required)
 
 1. [**Better WiFi Tools**](https://github.com/XK9274/better-wifi-miyoo) by XK9274  
-   *Better WiFi management for the MMP (OnionOS)*
+   *Better WiFi management for the MMP (Onion)*
 
 2. [**Cloud Saves**](https://github.com/hotcereal/cloud-saves-miyoo-mini-plus) by hotcereal  
    *Utilizing rclone, upload and download saves to and from your Miyoo Mini+*
@@ -51,4 +51,4 @@ Here you will find a selection of third party applications and tools compatible 
     *A simple KJV Bible reader*
 
 12. [**Wthr**](https://github.com/trashplusplus/wthr) by 0x3  
-    *Weather forecast app for OnionOS written in Go*
+    *Weather forecast app for Onion written in Go*

--- a/website/docs/07-apps/02-community-apps/screen-capture-toolkit.md
+++ b/website/docs/07-apps/02-community-apps/screen-capture-toolkit.md
@@ -1,6 +1,6 @@
 ---
 slug: /apps/screen-capture-toolkit
-description: A Screencapturing toolkit for the Miyoo Mini + (Twitch/VNC/RTMP/Outputfile)
+description: A Screencapturing toolkit for the Miyoo Mini Plus (Twitch/VNC/RTMP/Outputfile)
 ---
 
 # Screen Capture Toolkit
@@ -8,4 +8,4 @@ description: A Screencapturing toolkit for the Miyoo Mini + (Twitch/VNC/RTMP/Out
 
 [**Screen Capture Toolkit - official page**](https://github.com/XK9274/screencap-toolkit-miyoo)
 
-A Screencapturing toolkit for the Miyoo Mini + (Twitch/VNC/RTMP/Outputfile)
+A Screencapturing toolkit for the Miyoo Mini Plus (Twitch/VNC/RTMP/Outputfile)

--- a/website/docs/07-apps/02-community-apps/spotify-client.md
+++ b/website/docs/07-apps/02-community-apps/spotify-client.md
@@ -6,6 +6,6 @@ description: Builds ncspot for the Miyoo Mini + (contains appfolder).
 # Spotify Client
 <sup>by XK9274</sup>
 
-[**Better Wifi Tools - official page**](https://github.com/XK9274/ncspotcli-compile-miyoo)
+[**Better WiFi Tools - official page**](https://github.com/XK9274/ncspotcli-compile-miyoo)
 
 Builds ncspot for the Miyoo Mini + (contains appfolder).

--- a/website/docs/07-apps/02-community-apps/spotify-client.md
+++ b/website/docs/07-apps/02-community-apps/spotify-client.md
@@ -1,6 +1,6 @@
 ---
 slug: /apps/spotify-client
-description: Builds ncspot for the Miyoo Mini + (contains appfolder).
+description: Builds ncspot for the Miyoo Mini Plus (contains appfolder).
 ---
 
 # Spotify Client
@@ -8,4 +8,4 @@ description: Builds ncspot for the Miyoo Mini + (contains appfolder).
 
 [**Better WiFi Tools - official page**](https://github.com/XK9274/ncspotcli-compile-miyoo)
 
-Builds ncspot for the Miyoo Mini + (contains appfolder).
+Builds ncspot for the Miyoo Mini Plus (contains appfolder).

--- a/website/docs/07-apps/02-community-apps/wthr.md
+++ b/website/docs/07-apps/02-community-apps/wthr.md
@@ -1,6 +1,6 @@
 ---
 slug: /apps/wthr
-description: Weather forecast app for OnionOS.
+description: Weather forecast app for Onion.
 ---
 
 # Wthr

--- a/website/docs/07-apps/03-network-features/02-http-file-server.md
+++ b/website/docs/07-apps/03-network-features/02-http-file-server.md
@@ -7,7 +7,7 @@ slug: /network/http
 
 ![](https://github.com/OnionUI/Onion/assets/47260768/27adb5f7-2665-4b82-a8e0-9311651d89e1)
 
-The built-in HTTP file server will allow you to manage your files through a web browser on your phone, a PC or a tablet. Think of it as a website, hosted by your Miyoo Mini+. 
+The built-in HTTP file server will allow you to manage your files through a web browser on your phone, a PC or a tablet. Think of it as a website, hosted by your Miyoo Mini Plus. 
 
 
 ## Features

--- a/website/docs/07-apps/03-network-features/03-ssh-sftp.md
+++ b/website/docs/07-apps/03-network-features/03-ssh-sftp.md
@@ -7,7 +7,7 @@ slug: /network/ssh
 
 *![](https://github.com/OnionUI/Onion/assets/47260768/903ea3ab-00fb-4c01-857a-ca5b5ae24f08)*
 
-SSH provides a secure command line method to communicate with your Miyoo Mini+.
+SSH provides a secure command line method to communicate with your Miyoo Mini Plus.
 
 SFTP provides a secure file transfer method
 

--- a/website/docs/07-apps/03-network-features/04-ftp.md
+++ b/website/docs/07-apps/03-network-features/04-ftp.md
@@ -7,7 +7,7 @@ slug: /network/ftp
 
 ![](https://github.com/OnionUI/Onion/assets/47260768/7bfac01d-bfaa-4565-b10b-b2b2a0ea7f9c)
 
-Much like the HTTP server, FTP provides a method of transferring files between your Miyoo Mini+ and other devices such as a PC/Phone/Tablet. You'll need an FTP client installed on the second device.
+Much like the HTTP server, FTP provides a method of transferring files between your Miyoo Mini Plus and other devices such as a PC/Phone/Tablet. You'll need an FTP client installed on the second device.
 
 
 ## Features

--- a/website/docs/07-apps/03-network-features/05-telnet.md
+++ b/website/docs/07-apps/03-network-features/05-telnet.md
@@ -6,7 +6,7 @@ slug: /network/telnet
 
 *![](https://github.com/OnionUI/Onion/assets/47260768/62ee0d6c-1cce-43a4-976a-c8212850bf2f)*
 
-Telnet provides an unencrypted command line method to communicate with your Miyoo Mini+.
+Telnet provides an unencrypted command line method to communicate with your Miyoo Mini Plus.
 
 
 ## Features

--- a/website/docs/07-apps/03-network-features/07-vnc-server.md
+++ b/website/docs/07-apps/03-network-features/07-vnc-server.md
@@ -7,13 +7,13 @@ slug: /network/vnc
 
 ![](./assets/vnc.webp)
 
-Remote display and remote control of your Miyoo Mini+ from your computer thanks to VNC.
+Remote display and remote control of your Miyoo Mini Plus from your computer thanks to VNC.
 
 
 ## Features
 
-- Remote display of the Miyoo Mini+
-- Remote control of the Miyoo Mini+
+- Remote display of the Miyoo Mini Plus
+- Remote control of the Miyoo Mini Plus
 
 
 ## Enabling VNC access

--- a/website/docs/08-guides/01-advanced-guides/01-scraping.md
+++ b/website/docs/08-guides/01-advanced-guides/01-scraping.md
@@ -39,7 +39,7 @@ The `Imgs` folder name is case sensitive (must have a capital `I`). Examples wou
 
 ### Media selection
 
-**Use a (_Great!_) Custom Image Template Designed for OnionOS:**
+**Use a (_Great!_) Custom Image Template Designed for Onion:**
 
 **_Examples:_**<br/>
 ![image](https://user-images.githubusercontent.com/56418567/212767886-753a83ae-2f56-4255-a22d-f658ba656690.png)
@@ -83,6 +83,6 @@ This will automatically scrape images to the correct folders for Miyoo Mini.
 https://www.youtube.com/watch?v=RFu2DKRDq7o
 
 
-#### EASY Scraping art for retro games (MiYoo Mini Skraper tutorial on Onion OS) _by TechDweeb_
+#### EASY Scraping art for retro games (MiYoo Mini Skraper tutorial on Onion) _by TechDweeb_
 
 https://www.youtube.com/watch?v=DguILcIyZQE&ab_channel=TechDweeb

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,7 +18,7 @@ const oembedOpts = {
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Onion',
-  tagline: 'OS overhaul for Miyoo Mini and Mini+',
+  tagline: 'OS overhaul for Miyoo Mini and Mini Plus',
   favicon: 'img/favicon.png',
   trailingSlash: false,
 

--- a/website/src/pages/about.mdx
+++ b/website/src/pages/about.mdx
@@ -74,7 +74,7 @@ Onion has and always will be a community effort, and we want to give credit wher
 
 - **Olywa123** - *Amazing help to hundreds of Onion users, he made a lot of contributions like various documents/wiki/tutorials that eased the user experience tremendously.*
 - **DiMo** - *A lot of contributions, he made the default Onion theme and helped to improve theme capabilities, charging animations.*
-- **eggs** - *His retroarch port and tools are incredible. We are so gifted to have him working on this handheld. He also made the background onion process (keymon) that we still use in a modified form.*
+- **eggs** - *His RetroArch port and tools are incredible. We are so gifted to have him working on this handheld. He also made the background onion process (keymon) that we still use in a modified form.*
 - **[Introkun](https://github.com/introkun)** - *Improving apps (Clock, infoPanel/Screenshot Viewer), various optimisations, debugging & code reviews*
 - **[marchiore](https://github.com/marchiore)** - *Created the random game app for V4.1*
 - **jimgray** - *the original creator of Onion, without him the Onion community wouldn't have existed!*

--- a/website/src/pages/about.mdx
+++ b/website/src/pages/about.mdx
@@ -70,7 +70,7 @@ Has taken the lead as the main tester of everything that's going into Onion, ens
 
 ## Credits and acknowledgements
 
-Onion has and always will be a community effort, and we want to give credit where credit's due. The list below contains many of the noteworthy contributers to the Onion project. But, a list like this is almost impossible to maintain, and is in no way fully exhaustive of the entire community.
+Onion has and always will be a community effort, and we want to give credit where credit's due. The list below contains many of the noteworthy contributors to the Onion project. But, a list like this is almost impossible to maintain, and is in no way fully exhaustive of the entire community.
 
 - **Olywa123** - *Amazing help to hundreds of Onion users, he made a lot of contributions like various documents/wiki/tutorials that eased the user experience tremendously.*
 - **DiMo** - *A lot of contributions, he made the default Onion theme and helped to improve theme capabilities, charging animations.*


### PR DESCRIPTION
Documentation contained inconsistent capitalization, naming conventions, and grammatical errors across 37 files, creating search friction and reducing professionalism.

Changes
Product name standardization (40 instances)

Onion OS / OnionOS → Onion
retroarch / Retroarch → RetroArch
Retroachivements → RetroAchievements
Device name standardization (23 instances)

Miyoo Mini+ / Miyoo Mini + → Miyoo Mini Plus
Removed redundant (Plus) from "Miyoo Mini Plus (Plus)"
Homepage tagline in docusaurus.config.js updated
WiFi capitalization (7 instances)
Context-aware fixes:

wifi / Wifi → Wi-Fi (technical contexts: "equipped with Wi-Fi", "Wi-Fi connection")
Wifi → WiFi (feature names: "Better WiFi Tools")
Grammar corrections (14 instances)

Subject-verb: versions doesn't → don't, files consists → consist
Infinitives: allows to filter → allows you to filter
Typos: wall named → well named, contributers → contributors
Link integrity (3 instances)

Corrected internal links to use lowercase slugs: apps/RetroArch → apps/retroarch
Maintained case-sensitivity for file paths and external URLs
Scope
Changes limited to website/docs/, website/src/, and config files (for the change in the homepage). Historical content in versioned_docs/ and blog/ preserved.