### PR TITLE
support PSXONPSP660 BIOS filename case variants

### DIFF
--- a/static/build/RetroArch/.retroarch/cores/km_duckswanstation_xtreme_amped_libretro.info
+++ b/static/build/RetroArch/.retroarch/cores/km_duckswanstation_xtreme_amped_libretro.info
@@ -26,8 +26,8 @@ disk_control = "true"
 
 # BIOS / Firmware
 firmware_count = 5
-firmware0_desc = "psxonpsp660.bin (PSP PS1 BIOS)"
-firmware0_path = "psxonpsp660.bin"
+firmware0_desc = "PSXONPSP660.bin (PSP PS1 BIOS)"
+firmware0_path = "PSXONPSP660.bin"
 firmware0_opt = "true"
 firmware1_desc = "scph5500.bin (PS1 JP BIOS)"
 firmware1_path = "scph5500.bin"
@@ -41,6 +41,6 @@ firmware3_opt = "true"
 firmware4_desc = "ps1_rom.bin (PS3 PS1 BIOS)"
 firmware4_path = "ps1_rom.bin"
 firmware4_opt = "true"
-notes = "(!) psxonpsp660.bin (md5): c53ca5908936d412331790f4426c6c33|(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050||(!) ps1_rom.bin (md5): 81bbe60ba7a3d1cea1d48c14cbcc647b| This core also supports No-Intro BIOS images."
+notes = "(!) PSXONPSP660.bin (md5): c53ca5908936d412331790f4426c6c33|(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050||(!) ps1_rom.bin (md5): 81bbe60ba7a3d1cea1d48c14cbcc647b| This core also supports No-Intro BIOS images."
 
 description = "SwanStation is a fork of the Duckstation PlayStation 1 (aka PSX) emulator focusing on playability, speed, and long-term maintainability ported to libretro. A 'BIOS' ROM image is required to start the emulator and to play games. SwanStation includes hardware rendering (OpenGL, Vulkan and D3D11), upscaling, 24-bit color, and a dynamic recompiler (x86-64, ARMv7, AArch64)."

--- a/static/packages/RApp/Sony - PlayStation (PCSX standalone)/RApp/PCSX-ReARMed/launch.sh
+++ b/static/packages/RApp/Sony - PlayStation (PCSX standalone)/RApp/PCSX-ReARMed/launch.sh
@@ -12,6 +12,8 @@ cd $progdir
 if [ ! -f "${progdir}/bios/scph1001.bin" ]; then  # if no bios installed...
 	if [ -f "/mnt/SDCARD/BIOS/PSXONPSP660.bin" ]; then
 		cp -f "/mnt/SDCARD/BIOS/PSXONPSP660.bin" "${progdir}/bios/scph1001.bin"
+	elif [ -f "/mnt/SDCARD/BIOS/psxonpsp660.bin" ]; then
+		cp -f "/mnt/SDCARD/BIOS/psxonpsp660.bin" "${progdir}/bios/scph1001.bin"
 	elif [ -f "/mnt/SDCARD/BIOS/scph101.bin" ]; then
 		cp -f "/mnt/SDCARD/BIOS/scph101.bin" "${progdir}/bios/scph1001.bin"
 	elif [ -f "/mnt/SDCARD/BIOS/scph7001.bin" ]; then

--- a/static/packages/RApp/Sony - PlayStation (SwanStation)/RApp/swanstation/launch.sh
+++ b/static/packages/RApp/Sony - PlayStation (SwanStation)/RApp/swanstation/launch.sh
@@ -3,5 +3,58 @@ echo $0 $*
 progdir=`dirname "$0"`
 homedir=`dirname "$1"`
 
+biosdir=/mnt/SDCARD/BIOS
+swanconfig=
+pspbios=
+
+# Detect the filename using its stored spelling.
+for entry in "$biosdir"/*; do
+    [ -f "$entry" ] || continue
+
+    case "$(basename "$entry")" in
+        PSXONPSP660.bin)
+            pspbios="$entry"
+            break
+            ;;
+        psxonpsp660.bin)
+            pspbios="$entry"
+            ;;
+    esac
+done
+
+# SwanStation expects the PSP BIOS as lowercase while Onion documents
+# PSXONPSP660.bin. Provide both spellings in a temporary BIOS view.
+if [ -n "$pspbios" ]; then
+    swanbios=/tmp/swanstation-bios
+    swanconfig=/tmp/swanstation-bios.cfg
+
+    rm -rf "$swanbios"
+    mkdir -p "$swanbios"
+
+    for entry in "$biosdir"/* "$biosdir"/.[!.]*; do
+        [ -e "$entry" ] || continue
+        ln -s "$entry" "$swanbios/$(basename "$entry")"
+    done
+
+    ln -sf "$pspbios" "$swanbios/PSXONPSP660.bin"
+    ln -sf "$pspbios" "$swanbios/psxonpsp660.bin"
+
+    printf 'system_directory = "%s"\n' "$swanbios" > "$swanconfig"
+fi
+
 cd /mnt/SDCARD/RetroArch/
-HOME=/mnt/SDCARD/RetroArch/ $progdir/../../RetroArch/retroarch -v -L $progdir/../../RetroArch/.retroarch/cores/km_duckswanstation_xtreme_amped_libretro.so "$1"
+
+if [ -n "$swanconfig" ]; then
+    HOME=/mnt/SDCARD/RetroArch/ \
+        "$progdir/../../RetroArch/retroarch" \
+        --appendconfig="$swanconfig" \
+        -v \
+        -L "$progdir/../../RetroArch/.retroarch/cores/km_duckswanstation_xtreme_amped_libretro.so" \
+        "$1"
+else
+    HOME=/mnt/SDCARD/RetroArch/ \
+        "$progdir/../../RetroArch/retroarch" \
+        -v \
+        -L "$progdir/../../RetroArch/.retroarch/cores/km_duckswanstation_xtreme_amped_libretro.so" \
+        "$1"
+fi


### PR DESCRIPTION
Support both PSXONPSP660.bin and psxonpsp660.bin across PCSX standalone and SwanStation, while keeping uppercase as Onion’s preferred filename.

Tested on Miyoo Mini Plus: SwanStation was confirmed to open the lowercase BIOS path while only PSXONPSP660.bin existed on the SD, with the launcher providing the compatibility alias.