### PR TITLE
keymon: Refresh system state before acting on SELECT

### DIFF
--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -755,6 +755,12 @@ int main(void)
                 break;
             case HW_BTN_SELECT:
                 if (!comboKey_select && val == RELEASED) {
+                    // The cached state is only refreshed on /tmp/state_changed,
+                    // a MENU press or deepsleep(), so it can still be
+                    // MODE_UNKNOWN after boot or stale after returning from a
+                    // game. Re-read it here; this fires once per SELECT tap.
+                    system_state_update();
+
                     if (system_state == MODE_MAIN_UI) {
                         keyinput_send(HW_BTN_MENU, PRESSED);
                         keyinput_send(HW_BTN_MENU, RELEASED);


### PR DESCRIPTION
Fix intermittent SELECT -> MENU shortcut on Miyoo Mini v4 and Miyoo Flip.

`system_state` is a cached value, only re-read when `/tmp/state_changed`
exists, on a MENU press, or from `deepsleep()`. Two situations can leave it
wrong:

* after a fresh boot it's still `MODE_UNKNOWN`
* after returning from a game it's sometimes stale, when keymon consumes
  `/tmp/state_changed` before MainUI is back up

In both cases the SELECT -> MENU shortcut compares against the wrong value and
does nothing. It starts working once a state transition or MENU press forces an
update, which made it look intermittent rather than broken.

This re-reads the state in the handler before branching on it. The call sits
behind `!comboKey_select && val == RELEASED`, so it runs once per SELECT tap.

### Scope

Deliberately limited to SELECT. Five other handlers read the same cached value
and might have the same problem, but I couldn't reproduce any issues with
other key presses.

### Open question

Reported on v4 and Flip but not on Plus. I couldn't find a device-dependent
path in the state logic to explain that, so if anyone knows where the boot
ordering differs I'd like to hear it. The fix isn't device-specific either way.

### Testing

* Fresh boot, SELECT as the first input: shortcut works
* Launch a game, exit back to MainUI, SELECT: shortcut works
* SELECT combos still behave as before
