### PR TITLE
GameSwitcher: Favorites toggle + fix crashes and game switching

### DIFF
--- a/src/common/system/lang.h
+++ b/src/common/system/lang.h
@@ -34,6 +34,8 @@
 #define LANG_FALLBACK_LOAD "Load"
 #define LANG_FALLBACK_EXIT_TO_MENU "Exit to menu"
 #define LANG_FALLBACK_ADVANCED "Advanced"
+#define LANG_FALLBACK_REMOVE_FAVORITE "Remove favorite"
+#define LANG_FALLBACK_ADD_FAVORITE "Add favorite"
 
 static char **lang_list = NULL;
 
@@ -60,7 +62,9 @@ typedef enum {
     LANG_EXIT = 111,
     LANG_SAVE_EXIT = 112,
     LANG_NEXT = 300,
-    LANG_RESUME_UC = 301
+    LANG_RESUME_UC = 301,
+    LANG_REMOVE_FAVORITE = 302,
+    LANG_ADD_FAVORITE = 303
 } lang_hash;
 
 void lang_removeIconLabels(bool remove_icon_labels, bool remove_hints)

--- a/src/gameSwitcher/gs_favorites.h
+++ b/src/gameSwitcher/gs_favorites.h
@@ -1,0 +1,201 @@
+#ifndef GAME_SWITCHER_FAVORITES_H__
+#define GAME_SWITCHER_FAVORITES_H__
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "components/JsonGameEntry.h"
+#include "utils/file.h"
+#include "utils/json.h"
+#include "utils/log.h"
+
+#include "gs_model.h"
+
+// FAVORITES_PATH comes from components/JsonGameEntry.h, which is the canonical
+// definition and also documents the on-disk entry format.
+#define FAVORITES_TMP_PATTERN FAVORITES_PATH ".tmp.XXXXXX"
+
+static bool _favorites_pathMatches(const char *stored_rompath,
+                                   const char *rompath,
+                                   const char *resolved_rompath)
+{
+    if (stored_rompath == NULL || rompath == NULL) {
+        return false;
+    }
+
+    char *resolved_stored = file_resolvePath(stored_rompath);
+    bool matches = resolved_stored != NULL && resolved_rompath != NULL
+                       ? strcmp(resolved_stored, resolved_rompath) == 0
+                       : strcmp(stored_rompath, rompath) == 0;
+
+    free(resolved_stored);
+    return matches;
+}
+
+static bool _favorites_lineMatches(const char *line,
+                                   const char *rompath,
+                                   const char *resolved_rompath)
+{
+    cJSON *json = cJSON_Parse(line);
+    if (json == NULL) {
+        return false;
+    }
+
+    cJSON *stored_rompath = cJSON_GetObjectItemCaseSensitive(json, "rompath");
+    bool matches = cJSON_IsString(stored_rompath) &&
+                   stored_rompath->valuestring != NULL &&
+                   _favorites_pathMatches(stored_rompath->valuestring, rompath, resolved_rompath);
+
+    cJSON_Delete(json);
+    return matches;
+}
+
+static bool favorites_contains(Game_s *game)
+{
+    FILE *file = fopen(FAVORITES_PATH, "r");
+    if (file == NULL) {
+        return false;
+    }
+
+    const char *rompath = game->recentItem.rompath;
+    char *resolved_rompath = file_resolvePath(rompath);
+    char *line = NULL;
+    size_t capacity = 0;
+    bool found = false;
+
+    while (getline(&line, &capacity, file) != -1) {
+        if (_favorites_lineMatches(line, rompath, resolved_rompath)) {
+            found = true;
+            break;
+        }
+    }
+
+    free(line);
+    free(resolved_rompath);
+    fclose(file);
+    return found;
+}
+
+static bool _favorites_writeItem(FILE *file, const RecentItem *item)
+{
+    bool success = false;
+    cJSON *json = cJSON_CreateObject();
+    if (json == NULL) {
+        return false;
+    }
+
+    if (cJSON_AddStringToObject(json, "label", item->label) == NULL ||
+        cJSON_AddStringToObject(json, "rompath", item->rompath) == NULL ||
+        cJSON_AddStringToObject(json, "imgpath", item->imgpath) == NULL ||
+        cJSON_AddStringToObject(json, "launch", item->launch) == NULL ||
+        cJSON_AddNumberToObject(json, "type", item->type) == NULL) {
+        goto cleanup;
+    }
+
+    char *serialized = cJSON_PrintUnformatted(json);
+    if (serialized != NULL) {
+        success = fprintf(file, "%s\n", serialized) >= 0;
+        cJSON_free(serialized);
+    }
+
+cleanup:
+    cJSON_Delete(json);
+    return success;
+}
+
+static bool favorites_toggle(Game_s *game, bool *is_favorite_after)
+{
+    FILE *source = fopen(FAVORITES_PATH, "r");
+    if (source == NULL && errno != ENOENT) {
+        print_debug("Could not open favorites file");
+        return false;
+    }
+
+    struct stat source_stat;
+    bool source_stat_valid = stat(FAVORITES_PATH, &source_stat) == 0;
+
+    char temp_path[] = FAVORITES_TMP_PATTERN;
+    int temp_fd = mkstemp(temp_path);
+    if (temp_fd < 0) {
+        if (source != NULL) {
+            fclose(source);
+        }
+        print_debug("Could not create temporary favorites file");
+        return false;
+    }
+
+    fchmod(temp_fd, source_stat_valid ? source_stat.st_mode & 0777 : 0644);
+
+    FILE *target = fdopen(temp_fd, "w");
+    if (target == NULL) {
+        close(temp_fd);
+        unlink(temp_path);
+        if (source != NULL) {
+            fclose(source);
+        }
+        print_debug("Could not open temporary favorites file");
+        return false;
+    }
+
+    const char *rompath = game->recentItem.rompath;
+    char *resolved_rompath = file_resolvePath(rompath);
+    char *line = NULL;
+    size_t capacity = 0;
+    bool was_favorite = false;
+    bool success = true;
+
+    while (source != NULL && getline(&line, &capacity, source) != -1) {
+        if (_favorites_lineMatches(line, rompath, resolved_rompath)) {
+            was_favorite = true;
+            continue;
+        }
+
+        size_t line_length = strlen(line);
+        if (fwrite(line, 1, line_length, target) != line_length ||
+            (line_length > 0 && line[line_length - 1] != '\n' && fputc('\n', target) == EOF)) {
+            success = false;
+            break;
+        }
+    }
+
+    if (source != NULL && ferror(source)) {
+        success = false;
+    }
+    if (source != NULL) {
+        fclose(source);
+    }
+    free(line);
+    free(resolved_rompath);
+
+    if (success && !was_favorite) {
+        success = _favorites_writeItem(target, &game->recentItem);
+    }
+    if (success && fflush(target) != 0) {
+        success = false;
+    }
+    if (success && fsync(fileno(target)) != 0) {
+        success = false;
+    }
+    if (fclose(target) != 0) {
+        success = false;
+    }
+
+    if (!success || rename(temp_path, FAVORITES_PATH) != 0) {
+        unlink(temp_path);
+        print_debug("Could not update favorites file");
+        return false;
+    }
+
+    sync();
+    if (is_favorite_after != NULL) {
+        *is_favorite_after = !was_favorite;
+    }
+    return true;
+}
+
+#endif // GAME_SWITCHER_FAVORITES_H__

--- a/src/gameSwitcher/gs_keystate.h
+++ b/src/gameSwitcher/gs_keystate.h
@@ -37,6 +37,10 @@ static AppKeyState_s _gs_keystate = {
 
 void removeCurrentItem()
 {
+    // The save state scan reads game_list, so let it finish before the
+    // entries below the current one are shifted up.
+    popMenu_finishScan(false);
+
     Game_s *game = &game_list[appState.current_game];
 
     printf_debug("removing: %s\n", game->name);
@@ -213,11 +217,15 @@ void handleUpdateKeystateMain(AppState *state)
 void handleUpdateKeystatePopMenu(AppState *state)
 {
     KeyState *keystate = _gs_keystate.keystate;
-    ListItem *item = list_currentItem(&state->pop_menu_list);
+
+    if (!state->pop_menu_list._created) {
+        return;
+    }
 
     if (keystate[SW_BTN_B] == PRESSED) {
         state->pop_menu_open = false;
         state->changed = true;
+        return;
     }
 
     if (keystate[SW_BTN_A] == PRESSED) {
@@ -226,6 +234,12 @@ void handleUpdateKeystatePopMenu(AppState *state)
     else if (keystate[SW_BTN_A] == RELEASED && _gs_keystate.btn_a_pressed) {
         _gs_keystate.btn_a_pressed = false;
         list_activateItem(&state->pop_menu_list);
+
+        // An action may close or destroy the popup. Do not keep using the
+        // ListItem pointer or list storage after the callback returns.
+        if (state->quit || !state->pop_menu_open || !state->pop_menu_list._created) {
+            return;
+        }
     }
 
     if (keystate[SW_BTN_DOWN] >= PRESSED) {
@@ -237,7 +251,11 @@ void handleUpdateKeystatePopMenu(AppState *state)
             state->changed = true;
     }
 
+    // Navigation or an action can change the active item, so reacquire it.
+    ListItem *item = list_currentItem(&state->pop_menu_list);
     if (item != NULL && item->action_id == POP_MENU_ACTION_LOAD) {
+        popMenu_finishScan(true);
+
         if (keystate[SW_BTN_LEFT] >= PRESSED) {
             if (g_save_state_info.selected_slot > 0) {
                 g_save_state_info.selected_slot--;

--- a/src/gameSwitcher/gs_overlay.h
+++ b/src/gameSwitcher/gs_overlay.h
@@ -1,7 +1,9 @@
 #ifndef GAME_SWITCHER_OVERLAY_H
 #define GAME_SWITCHER_OVERLAY_H
 
+#include <errno.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -12,6 +14,7 @@
 #include "system/battery.h"
 #include "system/screenshot.h"
 #include "utils/msleep.h"
+#include "utils/process.h"
 #include "utils/str.h"
 
 #include "gs_appState.h"
@@ -20,6 +23,7 @@
 
 static pthread_t autosave_thread_pt;
 static bool autosave_thread_running = false;
+static pid_t overlay_retroarch_pid = 0;
 
 void setFbAsFirstRomScreen(void)
 {
@@ -75,6 +79,16 @@ void overlay_init()
     if (!appState.is_overlay) {
         return;
     }
+
+    // Remember the RetroArch instance this overlay belongs to.
+    overlay_retroarch_pid = 0;
+    for (int i = 0; i < 10 && overlay_retroarch_pid <= 0; i++) {
+        overlay_retroarch_pid = process_searchpid("retroarch");
+        if (overlay_retroarch_pid <= 0)
+            msleep(20);
+    }
+    if (overlay_retroarch_pid <= 0)
+        print_debug("Unable to capture RetroArch PID\n");
 
     retroarch_pause();
     system("playActivity stop_all &");
@@ -135,6 +149,17 @@ void overlay_resume(void)
     }
 }
 
+static bool _processPidExists(pid_t pid)
+{
+    if (pid <= 0)
+        return false;
+
+    if (kill(pid, 0) == 0)
+        return true;
+
+    return errno == EPERM;
+}
+
 void overlay_exit(void)
 {
     if (appState.is_overlay) {
@@ -145,22 +170,37 @@ void overlay_exit(void)
             pthread_join(autosave_thread_pt, NULL);
         }
 
-        // try graceful shutdown first
-        system("killall -TERM retroarch");
+        pid_t retroarch_pid = overlay_retroarch_pid;
+        overlay_retroarch_pid = 0;
 
-        // wait up to 5 seconds for RetroArch to exit
-        for (int i = 0; i < 10; i++) {
-            msleep(500);  // 0.5s x 10 = 5s
-            if (system("pidof retroarch > /dev/null") != 0) {
-                break;  // retroarch is gone
+        if (retroarch_pid <= 0) {
+            // The PID was never captured, so fall back to the old broad kill
+            // rather than leaving RetroArch running.
+            print_debug("No RetroArch PID captured, falling back to killall");
+            process_killall("retroarch");
+
+            for (int i = 0; i < 50 && process_isRunning("retroarch"); i++)
+                msleep(100);
+
+            if (process_isRunning("retroarch")) {
+                print_debug("RetroArch still running, force killing...");
+                temp_flag_set(".forceKillRetroarch", true);
+                system("killall -9 retroarch");
             }
         }
+        else if (_processPidExists(retroarch_pid)) {
+            kill(retroarch_pid, SIGTERM);
 
-        // if still running, force kill
-        if (system("pidof retroarch > /dev/null") == 0) {
-            print_debug("RetroArch still running, force killing...");
-            temp_flag_set(".forceKillRetroarch", true);
-            system("killall -9 retroarch");
+            // Wait up to 5 seconds for this specific instance to exit.
+            for (int i = 0; i < 50 && _processPidExists(retroarch_pid); i++)
+                msleep(100);
+
+            if (_processPidExists(retroarch_pid)) {
+                printf_debug("RetroArch PID %d still running, force killing...\n",
+                             retroarch_pid);
+                temp_flag_set(".forceKillRetroarch", true);
+                kill(retroarch_pid, SIGKILL);
+            }
         }
     }
 }

--- a/src/gameSwitcher/gs_popMenu.h
+++ b/src/gameSwitcher/gs_popMenu.h
@@ -8,6 +8,7 @@
 #include "utils/retroarch_cmd.h"
 
 #include "gs_appState.h"
+#include "gs_favorites.h"
 #include "gs_model.h"
 #include "gs_retroarch.h"
 
@@ -15,6 +16,7 @@
 #define POP_MENU_ACTION_SAVE 1
 #define POP_MENU_ACTION_LOAD 2
 #define POP_MENU_ACTION_EXIT 3
+#define POP_MENU_ACTION_FAVORITE 4
 
 typedef struct {
     int slots[10];
@@ -25,13 +27,23 @@ typedef struct {
 static SaveStateInfo_s g_save_state_info = {.slots = {0}, .slot_count = 0, .selected_slot = 0};
 
 static pthread_t g_scan_thread_pt;
+static bool g_scan_thread_started = false;
+static int g_scan_game_index = -1;
+
+static void setLoadPreview(void);
+static void popMenu_finishScan(bool update_preview);
 
 static bool g_save_thread_running = false;
 static bool g_save_thread_success = false;
 
 void popMenu_destroy(void)
 {
+    // The scan must be joined before the list can be freed. Older code let
+    // _scan_thread() call setLoadPreview() after list_free(), which could
+    // access freed ListItem storage and crash on a later popup open.
+    popMenu_finishScan(false);
     list_free(&appState.pop_menu_list);
+    appState.pop_menu_list = (List){0};
 }
 
 static bool _hasSaveStates(Game_s *game)
@@ -69,15 +81,15 @@ static bool _hasSaveStates(Game_s *game)
 
 static bool _scanSaveStates(Game_s *game, SaveStateInfo_s *info)
 {
+    info->slot_count = 0;
+    info->selected_slot = 0;
+
     char stateDirPath[4096];
     snprintf(stateDirPath, sizeof(stateDirPath), STATES_DIR "/%s", game->core_name);
 
     if (!exists(stateDirPath)) {
         return false;
     }
-
-    info->slot_count = 0;
-    info->selected_slot = 0;
 
     DIR *dir = opendir(stateDirPath);
     if (dir == NULL) {
@@ -155,8 +167,14 @@ static bool createSaveStatePath(Game_s *game, int slot, char *out_path, size_t o
     return true;
 }
 
-static void setLoadPreview()
+static void setLoadPreview(void)
 {
+    if (!appState.pop_menu_list._created ||
+        appState.current_game < 0 ||
+        appState.current_game >= game_list_len) {
+        return;
+    }
+
     ListItem *item = NULL;
     for (int i = 0; i < appState.pop_menu_list.item_count; i++) {
         if (appState.pop_menu_list.items[i].action_id == POP_MENU_ACTION_LOAD) {
@@ -166,6 +184,8 @@ static void setLoadPreview()
     }
 
     if (item != NULL) {
+        item->preview_path[0] = '\0';
+
         if (g_save_state_info.selected_slot >= 0 && g_save_state_info.selected_slot < g_save_state_info.slot_count) {
             const int real_slot = g_save_state_info.slots[g_save_state_info.selected_slot];
             Game_s *game = &game_list[appState.current_game];
@@ -174,9 +194,6 @@ static void setLoadPreview()
             if (createSaveStatePath(game, real_slot, stateFilePath, sizeof(stateFilePath))) {
                 snprintf(item->preview_path, sizeof(item->preview_path), "%s.png", stateFilePath);
             }
-        }
-        else {
-            item->preview_path[0] = '\0';
         }
 
         if (item->preview_ptr != NULL) {
@@ -238,9 +255,33 @@ static void *_save_thread(void *_)
 
 static void *_scan_thread(void *_)
 {
-    _scanSaveStates(&game_list[appState.current_game], &g_save_state_info);
-    setLoadPreview();
+    const int game_index = g_scan_game_index;
+    SaveStateInfo_s result = {.slots = {0}, .slot_count = 0, .selected_slot = 0};
+
+    if (game_index >= 0 && game_index < game_list_len) {
+        _scanSaveStates(&game_list[game_index], &result);
+    }
+
+    // Only publish plain scan data here. ListItem and SDL surface updates
+    // must stay on the main thread.
+    g_save_state_info = result;
     return NULL;
+}
+
+static void popMenu_finishScan(bool update_preview)
+{
+    if (g_scan_thread_started) {
+        pthread_join(g_scan_thread_pt, NULL);
+        g_scan_thread_started = false;
+    }
+
+    if (update_preview &&
+        appState.pop_menu_list._created &&
+        g_scan_game_index == appState.current_game) {
+        setLoadPreview();
+    }
+
+    g_scan_game_index = -1;
 }
 
 static bool _isSaveEnabled(void)
@@ -303,7 +344,10 @@ void action_saveGame(void *_)
 
 void action_loadGame(void *_)
 {
-    if (g_save_state_info.selected_slot < 0 && g_save_state_info.selected_slot >= g_save_state_info.slot_count) {
+    popMenu_finishScan(true);
+
+    if (g_save_state_info.selected_slot < 0 ||
+        g_save_state_info.selected_slot >= g_save_state_info.slot_count) {
         return;
     }
 
@@ -331,6 +375,8 @@ void action_loadGame(void *_)
 
 void popMenu_deleteSaveState(void)
 {
+    popMenu_finishScan(true);
+
     int selected_slot = g_save_state_info.selected_slot;
 
     if (selected_slot < 0 || selected_slot >= g_save_state_info.slot_count) {
@@ -382,6 +428,47 @@ void popMenu_deleteSaveState(void)
     }
 }
 
+// Both labels are Onion additions, registered next to LANG_NEXT and
+// LANG_RESUME_UC. Stock string 55 ("Add to favorites") would have come
+// pre-translated, but runs to 24 characters in some languages, which
+// overflows the popup, so these are deliberately shorter.
+static void _setFavoriteLabel(ListItem *item, bool is_favorite)
+{
+    snprintf(item->label, sizeof(item->label), "%s",
+             is_favorite
+                 ? lang_get(LANG_REMOVE_FAVORITE, LANG_FALLBACK_REMOVE_FAVORITE)
+                 : lang_get(LANG_ADD_FAVORITE, LANG_FALLBACK_ADD_FAVORITE));
+}
+
+void action_toggleFavorite(void *self)
+{
+    (void)self;
+
+    if (appState.current_game < 0 || appState.current_game >= game_list_len) {
+        return;
+    }
+
+    bool is_favorite = false;
+    if (!favorites_toggle(currentGame(), &is_favorite)) {
+        print_debug("Failed to update favorites");
+        return;
+    }
+
+    // Reacquire the item after file I/O instead of retaining the callback
+    // pointer. This stays valid even if popup ownership changes later.
+    if (appState.pop_menu_list._created) {
+        for (int i = 0; i < appState.pop_menu_list.item_count; i++) {
+            ListItem *item = &appState.pop_menu_list.items[i];
+            if (item->action_id == POP_MENU_ACTION_FAVORITE) {
+                _setFavoriteLabel(item, is_favorite);
+                break;
+            }
+        }
+    }
+
+    appState.changed = true;
+}
+
 void action_exitToMenu(void *_)
 {
     appState.exit_to_menu = true;
@@ -391,34 +478,63 @@ void action_exitToMenu(void *_)
 
 void popMenu_create(void)
 {
-    if (!appState.pop_menu_list._created) {
-        printf_debug("Creating pop menu for game %i\n", appState.current_game);
-        appState.pop_menu_list = list_create(4, LIST_SMALL);
+    if (appState.pop_menu_list._created ||
+        game_list_len <= 0 ||
+        appState.current_game < 0 ||
+        appState.current_game >= game_list_len) {
+        return;
+    }
 
+    printf_debug("Creating pop menu for game %i\n", appState.current_game);
+
+    const bool has_save = _isSaveEnabled();
+    const bool has_load = _isLoadEnabled();
+
+    // Five items are currently possible. Keep one spare slot so a future
+    // conditional item cannot silently write past the allocation.
+    appState.pop_menu_list = list_create(6, LIST_SMALL);
+
+    list_addItemWithLang(&appState.pop_menu_list,
+                         (ListItem){.label = LANG_FALLBACK_RESUME, .action = action_resumeGame, .action_id = POP_MENU_ACTION_RESUME},
+                         LANG_RESUME);
+
+    if (has_save) {
         list_addItemWithLang(&appState.pop_menu_list,
-                             (ListItem){.label = LANG_FALLBACK_RESUME, .action = action_resumeGame, .action_id = POP_MENU_ACTION_RESUME},
-                             LANG_RESUME);
+                             (ListItem){.label = LANG_FALLBACK_SAVE, .action = action_saveGame, .action_id = POP_MENU_ACTION_SAVE},
+                             LANG_SAVE);
+    }
 
-        if (_isSaveEnabled()) {
-            list_addItemWithLang(&appState.pop_menu_list,
-                                 (ListItem){.label = LANG_FALLBACK_SAVE, .action = action_saveGame, .action_id = POP_MENU_ACTION_SAVE},
-                                 LANG_SAVE);
-        }
-
-        if (_isLoadEnabled()) {
-            list_addItemWithLang(&appState.pop_menu_list,
-                                 (ListItem){.label = LANG_FALLBACK_LOAD, .action = action_loadGame, .action_id = POP_MENU_ACTION_LOAD},
-                                 LANG_LOAD);
-
-            // Load save states in a thread
-            pthread_create(&g_scan_thread_pt, NULL, _scan_thread, NULL);
-        }
-
+    if (has_load) {
         list_addItemWithLang(&appState.pop_menu_list,
-                             (ListItem){.label = LANG_FALLBACK_EXIT_TO_MENU, .action = action_exitToMenu, .action_id = POP_MENU_ACTION_EXIT},
-                             LANG_EXIT_TO_MENU);
+                             (ListItem){.label = LANG_FALLBACK_LOAD, .action = action_loadGame, .action_id = POP_MENU_ACTION_LOAD},
+                             LANG_LOAD);
+    }
 
-        appState.pop_menu_list.scroll_height = appState.pop_menu_list.item_count;
+    ListItem *favorite_item = list_addItem(
+        &appState.pop_menu_list,
+        (ListItem){.action = action_toggleFavorite, .action_id = POP_MENU_ACTION_FAVORITE});
+    if (favorite_item != NULL) {
+        _setFavoriteLabel(favorite_item, favorites_contains(currentGame()));
+    }
+
+    list_addItemWithLang(&appState.pop_menu_list,
+                         (ListItem){.label = LANG_FALLBACK_EXIT_TO_MENU, .action = action_exitToMenu, .action_id = POP_MENU_ACTION_EXIT},
+                         LANG_EXIT_TO_MENU);
+
+    appState.pop_menu_list.scroll_height = appState.pop_menu_list.item_count;
+
+    if (has_load) {
+        g_save_state_info = (SaveStateInfo_s){.slots = {0}, .slot_count = 0, .selected_slot = 0};
+        g_scan_game_index = appState.current_game;
+
+        if (pthread_create(&g_scan_thread_pt, NULL, _scan_thread, NULL) == 0) {
+            g_scan_thread_started = true;
+        }
+        else {
+            _scanSaveStates(currentGame(), &g_save_state_info);
+            setLoadPreview();
+            g_scan_game_index = -1;
+        }
     }
 }
 
@@ -428,13 +544,17 @@ void renderPopMenu(AppState *state)
         if (!appState.pop_menu_list._created) {
             popMenu_create();
         }
+        if (!appState.pop_menu_list._created) {
+            state->pop_menu_open = false;
+            return;
+        }
 
         ListItem *item = list_currentItem(&appState.pop_menu_list);
         SDL_Surface *transparent_bg = NULL;
 
         if (item != NULL && item->action_id == POP_MENU_ACTION_LOAD) {
             transparent_bg = appState.transparent_bg;
-            pthread_join(g_scan_thread_pt, NULL);
+            popMenu_finishScan(true);
         }
 
         theme_renderPopMenu(screen, state->view_mode == VIEW_NORMAL ? state->header_height : 0, &appState.pop_menu_list, transparent_bg);

--- a/static/build/miyoo/app/lang/en.lang
+++ b/static/build/miyoo/app/lang/en.lang
@@ -157,5 +157,7 @@
 	"154": "Fail to connect\nCheck your password\nOr reboot router",
 	"155": "Website",
 	"300": "NEXT",
-	"301": "RESUME"
+	"301": "RESUME",
+	"302": "Remove favorite",
+	"303": "Add favorite"
 }


### PR DESCRIPTION
Adds Favorites management to the GameSwitcher popup, and fixes several bugs found while extending that menu, including a race that killed the game you had just switched to.

### Switching games could kill the game you switched to

Switching games shortly after opening GameSwitcher killed the new game and relaunched it at the boot screen, and exiting from there autosaved over the real state.

`resumeGame()` writes `cmd_to_run.sh` and syncs before `overlay_exit()` runs, so runtime.sh can start the new game as soon as the old RetroArch process exits. `overlay_exit()` meanwhile was shutting RetroArch down by name: `killall -TERM retroarch`, a wait loop polling `pidof retroarch`, and a final `killall -9 retroarch` after the timeout. Neither command distinguishes instances.

If the old process exits while that wait loop is still running, `pidof` matches the newly launched instance instead, the loop runs to its full five seconds, and the final `killall -9` takes down the game that just started. Because `resumeGame()` also sets `force_auto_load_state`, the relaunch lands at the boot screen.

overlay_init() now captures the PID of the RetroArch instance that was running when GameSwitcher opened, and overlay_exit() signals and waits on that PID alone. On the normal captured-PID path, a new instance launched during the handoff is therefore not mistaken for the one being closed. If no PID was captured it falls back to the previous killall behaviour rather than risking leaving RetroArch running.

### Favorites

Adds a popup item that adds or removes the current game from `Roms/favourite.json`, showing `Add favorite` or `Remove favorite` as appropriate. The file is written through a temporary file and renamed into place, so an interrupted write cannot leave a partially written favorites list.

Both labels are new strings, `302` (remove) and `303` (add), registered alongside `NEXT` and `RESUME`. Stock string 55 ("Add to favorites") already exists in all shipped `.lang` files and would have been translated automatically, but it reaches 24 characters in Dutch and Hungarian and 23 in German and Portuguese, which does not fit comfortably in a `LIST_SMALL` row. The shorter wording is deliberate.

Only en.lang defines them so far; the other languages fall back to English until translations are added.

### Crash fixes

Making room for a fifth popup item exposed three existing lifetime and threading problems.

**`list_free()` leaves stale state behind** 
It frees the item array but leaves `item_count` and the `items` pointer unchanged, so a later `list_currentItem()` could return a pointer into freed memory. `popMenu_destroy()` now clears the struct after freeing it. Fixing this inside `list_free()` would have been tidier but changes behaviour for every other consumer, so it is left alone here.

**Saving from the popup continued using a destroyed list**
`action_saveGame()` destroys the popup from inside its own callback, and `handleUpdateKeystatePopMenu()` carried on afterwards and accessed the list that callback had already freed. The handler now stops touching the list once an action has destroyed it.

**The save-state scan thread modified UI objects** 
It called `setLoadPreview()` directly, which mutates `ListItem` state and frees SDL surfaces, while the main thread could be rendering those same objects. The worker now publishes only plain scan results; the preview update happens on the main thread after the join, keeping surfaces and `ListItem`s owned by the UI thread.

The popup also allocated space for exactly four items and `list_addItem()` does no bounds checking, so the allocation grows to six: five in use and one spare.

### Testing

On device:

- Switched games immediately after opening GameSwitcher: the new game starts and stays running, no delayed kill once the old instance exits, no relaunch to the boot screen, no autosave over the existing state
- Toggled Favorites on and off: the entry is added to and removed from `Roms/favourite.json`, and MainUI reflects the change
- Exited to menu with RetroArch running
