### PR TITLE
Improve framebuffer transitions and 640x480 handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ core: $(CACHE)/.setup
 	@cd $(SRC_DIR)/tree && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/pippi && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/cpuclock && BUILD_DIR=$(BIN_DIR) make
+	@cd $(SRC_DIR)/fbmode && BUILD_DIR=$(BIN_DIR) make
 
 # Build dependencies for installer
 	@mkdir -p $(INSTALLER_DIR)/bin

--- a/src/fbmode/Makefile
+++ b/src/fbmode/Makefile
@@ -1,0 +1,8 @@
+INCLUDE_UTILS = 0
+include ../common/config.mk
+
+TARGET = fbmode
+CFLAGS := $(CFLAGS) -Os
+
+include ../common/commands.mk
+include ../common/recipes.mk

--- a/src/fbmode/fbmode.c
+++ b/src/fbmode/fbmode.c
@@ -1,0 +1,441 @@
+/**
+ * fbmode - verified framebuffer mode change for the SigmaStar mi_fb driver
+ *
+ * Replaces `fbset` around resolution transitions on 752x560 panels
+ * (Miyoo Mini Flip / Mini Plus v4).
+ *
+ * The problem
+ * -----------
+ * The framebuffer is one fixed memory region and page boundaries are derived
+ * from the current geometry, so they MOVE when the resolution changes:
+ *
+ *     752x560 pages:  0x6721000  0x68BC400  0x6A57800   (page = 0x19B400)
+ *     640x480 pages:  0x6721000  0x684D000  0x6979000   (page = 0x12C000)
+ *
+ * 640 page 1 sits inside 752 page 0. After a 752->640 switch it can therefore
+ * contain pixels written at a 3008-byte stride which are then scanned out at
+ * 2560 bytes per row. If a controller or process flips onto that page while
+ * the incoming owner is still filling buffers, alternate frames appear
+ * sheared. This is the observed "dizzy lines" artifact.
+ *
+ * Stock `fbset -g $x $y $x $((y*2)) 32` also leaves two important details to
+ * chance: it always requests two virtual pages even when the current owner is
+ * using three, and it does not clear framebuffer memory whose page boundaries
+ * have just moved.
+ *
+ * What this does
+ * --------------
+ * The whole transition is kept on one framebuffer descriptor:
+ *
+ *   open -> GET var/fix info
+ *        -> optional preclear of the currently mapped framebuffer region
+ *        -> pan to page 0
+ *        -> PUT(FB_ACTIVATE_NOW|FB_ACTIVATE_FORCE)
+ *        -> poll GET until visible AND virtual geometry match the request
+ *        -> re-read fixed info to get the real post-switch line_length
+ *        -> clear all requested pages using that real pitch
+ *        -> pan to page 0 -> optional linger -> close
+ *
+ * --preclear is important. Clearing only after the mode switch leaves a short
+ * window where old pixels, written using the previous row pitch, can be scanned
+ * using the new pitch. Clearing first removes that window by construction.
+ * The post-switch clear is still useful because page boundaries and virtual
+ * layout have changed; it guarantees all pages in the new layout start clean.
+ *
+ * --preclear and --no-clear are independent and combine meaningfully:
+ *
+ *   (neither)               clear the new page layout after the latch
+ *   --preclear              clear everything before, then the new layout after
+ *   --preclear --no-clear   clear everything before, nothing after
+ *   --no-clear              do not clear at all; preserve existing content
+ *
+ * --preclear --no-clear is the preferred pairing when the screen should end up
+ * blank. The preclear covers the whole of smem_len, which is by definition a
+ * superset of the post-switch page layout, and zeroed bytes read as zero at any
+ * pitch. The post-switch clear would therefore only rewrite zeroes over zeroes,
+ * so skipping it removes a full-region memset from the transition without
+ * weakening the guarantee. Plain --no-clear is for transitions that must keep
+ * whatever is already on screen, such as a quick switch between games.
+ *
+ * Page count is explicit when the caller supplies --pages. This is useful on
+ * Onion because MainUI normally uses three 640x480 pages while RetroArch/game
+ * paths are expected to use two pages, matching stock yres_virtual = yres*2.
+ * If --pages is omitted, the current driver's page count is preserved, clamped
+ * to the known safe range of 2..3 pages. An explicit --pages outside that range
+ * is rejected rather than clamped, so a caller typo fails loudly instead of
+ * silently running a layout it did not ask for.
+ *
+ * Usage:
+ *   fbmode WxH [--pages N] [--preclear] [--no-clear] [--linger MS]
+ *              [--timeout MS]
+ *   fbmode --probe        report current geometry to stdout, change nothing
+ *
+ * Diagnostics are written to stderr. --probe writes machine-readable state to
+ * stdout and is the only normal stdout output, so shell callers can parse it
+ * without diagnostic text corrupting the result.
+ *
+ * Exit codes:
+ *   0  requested visible/virtual geometry latched and verified
+ *   2  invalid arguments, mmap failure, ioctl failure, or invalid layout
+ *   3  timed out waiting for the driver to report the requested layout
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/fb.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef FBIO_WAITFORVSYNC
+#define FBIO_WAITFORVSYNC _IOW('F', 0x20, uint32_t)
+#endif
+
+#define FB_DEV "/dev/fb0"
+
+/*
+ * Diagnostics intentionally go to stderr.
+ *
+ * runtime.sh uses `fbmode --probe` as a machine-readable query, so stdout must
+ * remain clean. Keeping diagnostics on stderr also lets Onion decide whether
+ * to discard them or route them into its existing runtime logging without this
+ * helper opening/writing its own SD-card log on every framebuffer transition.
+ *
+ * In other words:
+ *
+ *     stdout  = probe data only
+ *     stderr  = human-readable diagnostics
+ *
+ * That separation is part of the shell API, not just a logging preference.
+ */
+
+static long now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000L + ts.tv_nsec / 1000000L;
+}
+
+static void lg(const char *fmt, ...)
+{
+    va_list ap;
+
+    fputs("fbmode: ", stderr);
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fputc('\n', stderr);
+}
+
+/*
+ * Best-effort vertical-sync wait.
+ *
+ * SigmaStar builds differ in how completely FBIO_WAITFORVSYNC is implemented,
+ * so failure is deliberately not fatal. The correctness of the transition does
+ * not depend on this ioctl: correctness comes from verifying the post-PUT
+ * FBIOGET_VSCREENINFO state. VSYNC is only used to reduce the chance of asking
+ * the display controller to pan/commit halfway through a scanout.
+ */
+static void vsync(int fd)
+{
+    uint32_t crtc = 0;
+    ioctl(fd, FBIO_WAITFORVSYNC, &crtc);
+}
+
+/*
+ * Clear exactly `len` bytes of the framebuffer mapping.
+ *
+ * This helper is used for two different clears:
+ *
+ *   1. PRE-CLEAR: clear the complete old framebuffer memory region before a
+ *      geometry change. This removes pixels laid out at the old stride before
+ *      the driver starts interpreting the same memory with a new stride.
+ *
+ *   2. POST-CLEAR: after the new mode has latched, clear exactly the pages that
+ *      make up the new virtual framebuffer, using the driver's newly reported
+ *      line_length.
+ *
+ * mmap failure is treated as a transition failure. Silently continuing would
+ * defeat the purpose of fbmode: the mode could be accepted while stale pixels
+ * remain in memory at page offsets/strides belonging to the previous geometry.
+ *
+ * msync is retained even though framebuffer mappings are device memory rather
+ * than ordinary files. On this target it is cheap compared with the transition
+ * itself, and makes the intent explicit that all zeroing should be visible to
+ * the framebuffer owner before the mapping is released.
+ */
+static int clear_bytes(int fd, size_t len)
+{
+    uint8_t *fb;
+
+    if (len == 0)
+        return 0;
+
+    fb = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (fb == MAP_FAILED) {
+        lg("mmap failed: %s", strerror(errno));
+        return -1;
+    }
+
+    memset(fb, 0, len);
+    msync(fb, len, MS_SYNC);
+    munmap(fb, len);
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    int fd, want_x = 0, want_y = 0, pages = 0, pages_specified = 0;
+    int do_clear = 1, preclear = 0, linger_ms = 0, timeout_ms = 400, probe = 0;
+    struct fb_var_screeninfo v, chk;
+    struct fb_fix_screeninfo f;
+    uint32_t want_y_virtual;
+    long t0;
+
+    /*
+     * Argument parsing intentionally stays small: fbmode is an internal Onion
+     * helper, not a general fbset replacement. Unknown arguments are ignored so
+     * old callers that still pass `-v` remain compatible.
+     */
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--probe"))
+            probe = 1;
+        else if (!strcmp(argv[i], "--preclear"))
+            preclear = 1;
+        else if (!strcmp(argv[i], "--no-clear"))
+            do_clear = 0;
+        else if (!strcmp(argv[i], "-v"))
+            ; /* backwards-compatible no-op: diagnostics are always stderr */
+        else if (!strcmp(argv[i], "--pages") && i + 1 < argc) {
+            /* Track presence separately from value: atoi() maps both "0" and
+             * non-numeric text to 0, and neither should be mistaken for the
+             * caller having omitted --pages entirely. */
+            pages = atoi(argv[++i]);
+            pages_specified = 1;
+        }
+        else if (!strcmp(argv[i], "--linger") && i + 1 < argc)
+            linger_ms = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--timeout") && i + 1 < argc)
+            timeout_ms = atoi(argv[++i]);
+        else if (strchr(argv[i], 'x'))
+            sscanf(argv[i], "%dx%d", &want_x, &want_y);
+    }
+
+    if ((fd = open(FB_DEV, O_RDWR)) < 0) {
+        lg("open %s failed: %s", FB_DEV, strerror(errno));
+        return 2;
+    }
+
+    if (ioctl(fd, FBIOGET_VSCREENINFO, &v) < 0 ||
+        ioctl(fd, FBIOGET_FSCREENINFO, &f) < 0) {
+        lg("initial GET failed: %s", strerror(errno));
+        close(fd);
+        return 2;
+    }
+
+    /* Probe mode deliberately does not change any state. Keep its stdout
+     * machine-readable because runtime.sh uses it to avoid redundant commits
+     * and to verify page count as well as visible resolution. */
+    if (probe) {
+        printf("%ux%u virtual %ux%u bpp %u line_length %u pages %u\n",
+               v.xres, v.yres, v.xres_virtual, v.yres_virtual,
+               v.bits_per_pixel, f.line_length,
+               v.yres ? v.yres_virtual / v.yres : 0);
+        close(fd);
+        return 0;
+    }
+
+    /* A non-probe invocation must name a real visible geometry. */
+    if (want_x <= 0 || want_y <= 0) {
+        lg("missing or invalid WxH mode");
+        close(fd);
+        return 2;
+    }
+
+    /* Preserve the current page count only when the caller did not specify
+     * one. Onion's known useful states are two pages (RetroArch/game paths)
+     * and three pages (MainUI), so clamp inherited values to that range. */
+    if (!pages_specified) {
+        pages = v.yres ? (int)(v.yres_virtual / v.yres) : 2;
+        if (pages < 2)
+            pages = 2;
+        if (pages > 3)
+            pages = 3;
+    } else if (pages < 2 || pages > 3) {
+        lg("invalid page count: %d", pages);
+        close(fd);
+        return 2;
+    }
+
+    /*
+     * Virtual height is the page count expressed in scanlines. Keep this value
+     * separate because we verify it after the PUT. Merely seeing the requested
+     * visible WxH is not enough: the driver may still be using the wrong number
+     * of backing pages.
+     */
+    want_y_virtual = (uint32_t)want_y * (uint32_t)pages;
+
+    /* Preclear the complete currently mapped memory region before changing
+     * geometry. Page boundaries move when pitch/height change, so clearing only
+     * the future pages after the PUT leaves a short interval where old-stride
+     * pixels can be interpreted with the new stride. */
+    if (preclear && f.smem_len && clear_bytes(fd, f.smem_len) < 0) {
+        close(fd);
+        return 2;
+    }
+
+    /* Park scanout on page 0 before changing pitch and page boundaries. This
+     * avoids asking the driver to re-base an already-offset scanout while also
+     * changing the geometry that defines where each page begins. */
+    if (v.yoffset != 0 || v.xoffset != 0) {
+        v.xoffset = 0;
+        v.yoffset = 0;
+        v.activate = FB_ACTIVATE_VBL;
+        if (ioctl(fd, FBIOPAN_DISPLAY, &v) < 0) {
+            lg("initial PAN failed: %s", strerror(errno));
+            close(fd);
+            return 2;
+        }
+        vsync(fd);
+    }
+
+    /*
+     * Build the exact layout we want. xres_virtual intentionally matches xres:
+     * Onion flips vertically between full-screen pages; there is no horizontal
+     * panning requirement here. Both offsets start at zero so the commit itself
+     * does not inherit a page offset from the previous owner.
+     */
+    v.xres = v.xres_virtual = (uint32_t)want_x;
+    v.yres = (uint32_t)want_y;
+    v.yres_virtual = want_y_virtual;
+    v.xoffset = v.yoffset = 0;
+    v.bits_per_pixel = 32;
+    /* FORCE defeats the driver's "same mode, skip it" shortcut. That matters
+     * when visible WxH is unchanged but virtual geometry/page count needs to be
+     * repaired, e.g. 752x560 with three pages -> 752x560 with two pages. */
+    v.activate = FB_ACTIVATE_NOW | FB_ACTIVATE_FORCE;
+
+    /*
+     * A best-effort VSYNC before the PUT avoids committing in the middle of a
+     * scan where supported. FB_ACTIVATE_FORCE is important because a same-WxH
+     * request may still be changing virtual height/page count.
+     */
+    vsync(fd);
+    if (ioctl(fd, FBIOPUT_VSCREENINFO, &v) < 0) {
+        lg("PUT %dx%d failed: %s", want_x, want_y, strerror(errno));
+        close(fd);
+        return 2;
+    }
+
+    /* ioctl success only means the request was accepted. Do not return until
+     * the driver itself reports both the requested visible geometry and the
+     * requested virtual layout. Checking yres_virtual is important because a
+     * same-WxH transition can still be changing two pages to three or vice
+     * versa. Initialize chk first so timeout diagnostics are always defined,
+     * even if every GET during polling fails. */
+    chk = v;
+    t0 = now_ms();
+    for (;;) {
+        if (ioctl(fd, FBIOGET_VSCREENINFO, &chk) == 0 &&
+            chk.xres == (uint32_t)want_x &&
+            chk.yres == (uint32_t)want_y &&
+            chk.xres_virtual == (uint32_t)want_x &&
+            chk.yres_virtual == want_y_virtual)
+            break;
+
+        if (now_ms() - t0 > timeout_ms) {
+            lg("TIMEOUT: driver reports %ux%u virtual %ux%u",
+               chk.xres, chk.yres, chk.xres_virtual, chk.yres_virtual);
+            close(fd);
+            return 3;
+        }
+        /* 2 ms is short enough to observe the latch closely without spinning. */
+        usleep(2000);
+    }
+
+    /*
+     * Fixed screen info must be re-read after the latch. In particular,
+     * line_length belongs to the active mode and is the only safe authority for
+     * row pitch. Using `xres * 4` would assume the driver never pads rows.
+     */
+    if (ioctl(fd, FBIOGET_FSCREENINFO, &f) < 0) {
+        lg("final GET fix failed: %s", strerror(errno));
+        close(fd);
+        return 2;
+    }
+
+    /* Re-read fixed info after the mode latches because line_length is the
+     * authority on framebuffer row pitch. Never derive the clear stride from
+     * xres*4: the driver is free to pad scanlines. Clear only the requested new
+     * page layout and verify that it fits inside the advertised framebuffer
+     * memory before touching it. */
+    /*
+     * Clear the new virtual layout page-by-page as one contiguous range. The
+     * page size comes from real line_length * visible height, not from WxH*4.
+     *
+     * Checking the requested length against smem_len is defensive but useful:
+     * it prevents a bad page-count/driver response from turning a display fix
+     * into an out-of-range framebuffer write.
+     */
+    if (f.smem_len) {
+        size_t page_bytes = (size_t)f.line_length * chk.yres;
+        size_t clear_len = page_bytes * (size_t)pages;
+
+        /*
+         * Validate the latched layout even when clearing is skipped. A page
+         * layout that does not fit in framebuffer memory is an invalid result
+         * regardless of whether this invocation intends to write to it, and
+         * reporting it lets the caller fall back rather than hand a bad
+         * layout to the incoming owner.
+         */
+        if (clear_len > f.smem_len) {
+            lg("framebuffer too small: need %zu bytes, have %u",
+               clear_len, f.smem_len);
+            close(fd);
+            return 2;
+        }
+
+        if (do_clear && clear_bytes(fd, clear_len) < 0) {
+            close(fd);
+            return 2;
+        }
+    }
+
+    /* Finish on page 0. The incoming owner can then allocate/fill its own
+     * buffers from a known scanout base instead of inheriting an arbitrary page
+     * offset from the previous owner. */
+    chk.xoffset = chk.yoffset = 0;
+    chk.activate = FB_ACTIVATE_VBL;
+    if (ioctl(fd, FBIOPAN_DISPLAY, &chk) < 0) {
+        lg("final PAN failed: %s", strerror(errno));
+        close(fd);
+        return 2;
+    }
+    vsync(fd);
+
+    /*
+     * At this point all conditions fbmode promises are true:
+     *   - the driver reports the requested visible geometry;
+     *   - the requested virtual page layout is active;
+     *   - requested pages have been cleared at the active pitch (unless
+     *     --no-clear was explicitly requested);
+     *   - scanout is parked on page 0.
+     */
+    lg("%dx%d latched in %ldms, %d pages, pitch %u",
+       want_x, want_y, now_ms() - t0, pages, f.line_length);
+
+    /* Keep fb0 open briefly when requested. On this driver that gives the
+     * incoming process time to open the framebuffer before this transition
+     * descriptor disappears, which proved useful around ownership handoffs. */
+    if (linger_ms > 0)
+        usleep((useconds_t)linger_ms * 1000);
+
+    close(fd);
+    return 0;
+}

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -848,7 +848,19 @@ get_screen_resolution() {
         touch /tmp/get_screen_resolution_failed
     fi
 
-    if [ "$screen_resolution" = "752x560" ] && [ "$(/etc/fw_printenv miyoo_version | cut -d'=' -f2)" -ge "202310271401" ]; then
+    if [ -f "$sysdir/config/.force640Res" ]; then
+        log "get_screen_resolution: .force640Res set, forcing 640x480"
+        rm -f /tmp/new_res_available
+        screen_resolution="640x480"
+
+        if [ -x "$sysdir/bin/fbmode" ]; then
+            if ! $sysdir/bin/fbmode 640x480 --pages 3 --preclear --no-clear \
+                --linger 150 --timeout 800; then
+                log "fbmode failed in forced 640 mode, falling back to fbset"
+                fbset -g 640 480 640 1440 32
+            fi
+        fi
+    elif [ "$screen_resolution" = "752x560" ] && [ "$(/etc/fw_printenv miyoo_version | cut -d'=' -f2)" -ge "202310271401" ]; then
         touch /tmp/new_res_available
     else
         # can't use 752x560 without appropriate firmware or screen

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -232,6 +232,34 @@ launch_main_ui() {
 
     mute_theme_bgm
 
+    # Prepare MainUI's three-page 640x480 layout before SDL starts.
+    if [ -x "$sysdir/bin/fbmode" ] && [ -f /tmp/new_res_available ]; then
+        # Skip when already correct: arriving from init_system, or from a
+        # previous MainUI launch, there is nothing to do, and skipping avoids
+        # clearing whatever is on screen. Any real change preclears, so the
+        # pitch never changes with stale pixels still in memory.
+        # --probe: WxH virtual WxH bpp N line_length N pages N
+        probe=$($sysdir/bin/fbmode --probe 2> /dev/null)
+        current_res=$(echo "$probe" | awk '{print $1}')
+        current_virtual=$(echo "$probe" | awk '{print $3}')
+        current_bpp=$(echo "$probe" | awk '{print $5}')
+        current_pages=$(echo "$probe" | awk '{print $NF}')
+
+        if [ "$current_res" = "640x480" ] &&
+           [ "$current_virtual" = "640x1440" ] &&
+           [ "$current_bpp" = "32" ] &&
+           [ "$current_pages" = "3" ]; then
+            log "Framebuffer already 640x480/3, preserving"
+        else
+            if ! $sysdir/bin/fbmode 640x480 --pages 3 --preclear --no-clear \
+                --linger 150 --timeout 500; then
+                log "fbmode failed before MainUI, falling back to fbset"
+                fbset -g 640 480 640 1440 32
+            fi
+            notify_resolution_change
+        fi
+    fi
+
     # MainUI launch
     cd $miyoodir/app
     PATH="$miyoodir/app:$PATH" \
@@ -293,6 +321,11 @@ check_is_game() {
     echo "$1" | grep -q "retroarch/cores" || echo "$1" | grep -q "/../../Roms/" || echo "$1" | grep -q "/mnt/SDCARD/Roms/"
 }
 
+notify_resolution_change() {
+    killall -SIGUSR1 batmon
+    killall -SIGUSR1 keymon
+}
+
 change_resolution() {
     res_x=""
     res_y=""
@@ -306,12 +339,29 @@ change_resolution() {
     fi
     log "Changing resolution to $res_x x $res_y"
 
-    bootScreen clear
+    if [ -x "$sysdir/bin/fbmode" ]; then
+        probe=$($sysdir/bin/fbmode --probe 2> /dev/null)
+        current_res=$(echo "$probe" | cut -d' ' -f1)
+        current_pages=$(echo "$probe" | awk '{print $NF}')
 
-    fbset -g "$res_x" "$res_y" "$res_x" "$((res_y * 2))" 32
-    # inform batmon and keymon of resolution change
-    killall -SIGUSR1 batmon
-    killall -SIGUSR1 keymon
+        # Keep game-side mode changes at the stock two-page layout.
+        if [ "$current_res" = "${res_x}x${res_y}" ] && [ "$current_pages" = "2" ]; then
+            notify_resolution_change
+            return
+        fi
+
+        if ! $sysdir/bin/fbmode "${res_x}x${res_y}" --pages 2 \
+            --preclear --linger 120 --timeout 500; then
+            log "fbmode failed, falling back to fbset"
+            bootScreen clear
+            fbset -g "$res_x" "$res_y" "$res_x" "$((res_y * 2))" 32
+        fi
+    else
+        bootScreen clear
+        fbset -g "$res_x" "$res_y" "$res_x" "$((res_y * 2))" 32
+    fi
+
+    notify_resolution_change
 }
 
 launch_game() {
@@ -432,8 +482,35 @@ launch_game() {
             retval=$?
 
             if [ -f /tmp/new_res_available ]; then
-                # Restore resolution
-                change_resolution "640x480"
+                # infoPanel caches the old geometry and must not survive a mode change.
+                killall infoPanel 2>/dev/null
+                sleep 0.01
+                killall -9 infoPanel 2>/dev/null
+                rm -f /tmp/dismiss_info_panel
+
+                if [ -f /tmp/quick_switch ] || [ -f "$sysdir/.runGameSwitcher" ]; then
+                    # A handoff is pending. Whoever runs next owns the mode, so
+                    # leave the framebuffer alone rather than transitioning to
+                    # 640x480 only for the next step to transition away again.
+                    log "Handoff pending, preserving framebuffer"
+                elif [ -f /tmp/.offOrder ]; then
+                    # Shutting down. Nothing after this renders except the
+                    # shutdown screen, which reads the live geometry, and
+                    # keymon may already have one on screen from deepsleep.
+                    # Changing the mode underneath it shears whatever it is
+                    # still drawing.
+                    log "Shutdown pending, preserving framebuffer"
+                else
+                    if [ -x "$sysdir/bin/fbmode" ]; then
+                        if ! $sysdir/bin/fbmode 640x480 --pages 2 --preclear --no-clear \
+                            --linger 150 --timeout 500; then
+                            log "fbmode failed returning to MainUI, falling back to fbset"
+                            fbset -g 640 480 640 960 32
+                        fi
+                    fi
+
+                    change_resolution "640x480"
+                fi
             fi
 
             if [ $is_game -eq 1 ] && [ ! -f /tmp/.offOrder ] && [ -f /tmp/.displaySavingMessage ]; then
@@ -651,6 +728,32 @@ check_switcher() {
 launch_switcher() {
     log "\n:: Launch switcher"
     cd $sysdir
+
+    # GameSwitcher owns its framebuffer requirement: a game exiting toward it
+    # leaves the mode alone, so this is the only place 752x560 is established.
+    if [ -f /tmp/new_res_available ] && [ -x "$sysdir/bin/fbmode" ]; then
+        # --probe: WxH virtual WxH bpp N line_length N pages N
+        probe=$($sysdir/bin/fbmode --probe 2> /dev/null)
+        current_res=$(echo "$probe" | awk '{print $1}')
+        current_virtual=$(echo "$probe" | awk '{print $3}')
+        current_bpp=$(echo "$probe" | awk '{print $5}')
+        current_pages=$(echo "$probe" | awk '{print $NF}')
+
+        if [ "$current_res" = "752x560" ] &&
+           [ "$current_virtual" = "752x1120" ] &&
+           [ "$current_bpp" = "32" ] &&
+           [ "$current_pages" = "2" ]; then
+            log "Framebuffer already 752x560/2, preserving"
+        else
+            if ! $sysdir/bin/fbmode 752x560 --pages 2 --preclear --no-clear \
+                --linger 150 --timeout 500; then
+                log "fbmode failed before GameSwitcher, falling back to fbset"
+                fbset -g 752 560 752 1120 32
+            fi
+            notify_resolution_change
+        fi
+    fi
+
     start_audioserver
     LD_PRELOAD="$miyoodir/lib/libpadsp.so" gameSwitcher
     rm $sysdir/.runGameSwitcher
@@ -820,6 +923,18 @@ init_system() {
     echo 1 > /sys/class/pwm/pwmchip0/pwm0/enable
 
     get_screen_resolution
+
+    # Establish MainUI's layout before the boot screen is drawn. Doing it here
+    # means the boot screen is painted in the mode MainUI will use, so nothing
+    # has to clear it later and it stays up until MainUI paints over it. On
+    # 640-only devices this is skipped and behaviour is unchanged.
+    if [ -f /tmp/new_res_available ] && [ -x "$sysdir/bin/fbmode" ]; then
+        if ! $sysdir/bin/fbmode 640x480 --pages 3 --preclear --no-clear \
+            --linger 150 --timeout 500; then
+            log "fbmode failed preparing MainUI layout, falling back to fbset"
+            fbset -g 640 480 640 1440 32
+        fi
+    fi
 }
 
 device_uuid=$(read_uuid)

--- a/static/build/.tmp_update/script/change_resolution.sh
+++ b/static/build/.tmp_update/script/change_resolution.sh
@@ -4,9 +4,6 @@ sysdir=/mnt/SDCARD/.tmp_update
 logfile=$(basename "$0" .sh)
 . $sysdir/script/log.sh
 
-res_x=""
-res_y=""
-
 if [ -n "$1" ]; then
     res_x=$(echo "$1" | cut -d 'x' -f 1)
     res_y=$(echo "$1" | cut -d 'x' -f 2)
@@ -16,8 +13,26 @@ else
 fi
 log "Changing resolution to $res_x x $res_y"
 
-fbset -g "$res_x" "$res_y" "$res_x" "$((res_y * 2))" 32
+if [ -x "$sysdir/bin/fbmode" ]; then
+    probe=$($sysdir/bin/fbmode --probe 2> /dev/null)
+    current_res=$(echo "$probe" | cut -d' ' -f1)
+    current_pages=$(echo "$probe" | awk '{print $NF}')
 
-# inform batmon and keymon of resolution change
+    # Keep RetroArch-facing transitions at stock's two-page layout.
+    if [ "$current_res" != "${res_x}x${res_y}" ] || [ "$current_pages" != "2" ]; then
+        if ! "$sysdir/bin/fbmode" "${res_x}x${res_y}" --pages 2 \
+            --preclear --linger 120 --timeout 500; then
+            log "fbmode failed, falling back to fbset"
+            fbset -g "$res_x" "$res_y" "$res_x" "$((res_y * 2))" 32
+        else
+            log "Committed ${res_x}x${res_y} (2 pages), was ${current_res:-unknown} (${current_pages:-?} pages)"
+        fi
+    else
+        log "Already at ${res_x}x${res_y} (2 pages), skipping mode change"
+    fi
+else
+    fbset -g "$res_x" "$res_y" "$res_x" "$((res_y * 2))" 32
+fi
+
 killall -SIGUSR1 batmon
 killall -SIGUSR1 keymon

--- a/static/dist/miyoo/app/.tmp_update/install.sh
+++ b/static/dist/miyoo/app/.tmp_update/install.sh
@@ -35,6 +35,14 @@ main() {
         sleep 1
     fi
 
+    # installUI has a fixed 640x480 layout and nothing up to this point has
+    # established a framebuffer geometry, so it starts on whatever the
+    # firmware left active. Clear before the change, not after: the
+    # firmware's contents would otherwise be scanned out at the new stride
+    # until installUI paints over them.
+    dd if=/dev/zero of=/dev/fb0 bs=1M 2> /dev/null
+    fbset -g 640 480 640 960 32
+
     check_device_model
     check_install_ra
 


### PR DESCRIPTION
This PR improves framebuffer transitions on 752x560-capable devices, adds an optional 640x480 mode, and fixes the installer starting before a suitable framebuffer geometry has been established.

The changes are split into three commits so each part can still be reviewed independently:

1. use `fbmode` for verified runtime framebuffer transitions
2. add the optional `.force640Res` override
3. clear and establish 640x480 before the installer UI starts

### 1. Verified framebuffer transitions

Runtime currently uses `fbset` for resolution changes. It requests a geometry but does not verify when the driver has actually latched it, always requests two virtual pages, and does not clear framebuffer memory whose page boundaries have just moved.

That last point is what produces the sheared frames seen around 752x560 handoffs. The 640x480 and 752x560 layouts do not divide framebuffer memory at the same offsets, so bytes written using the 752x560 stride can briefly be scanned out using the 640x480 stride.

This adds `fbmode`, a small framebuffer helper that:

* waits for the requested visible and virtual geometry to be reported
* uses the driver's actual post-switch `line_length`
* supports pre-clearing before a pitch change
* leaves scanout parked on page 0
* exposes `--probe` so redundant mode changes can be skipped
* reports failure back to runtime so existing `fbset` fallbacks can be used

#### GameSwitcher handoff

`launch_switcher` becomes the single owner of GameSwitcher's 752x560 requirement.

A game exiting toward GameSwitcher leaves the framebuffer alone instead of dropping to 640x480 only for the next stage to switch it straight back.

Before launching GameSwitcher, runtime probes the current framebuffer and leaves an already-correct 752x560 two-page layout untouched, avoiding a forced same-mode relatch when arriving from a 752x560 game.

#### MainUI handoff

On 752x560-capable devices, runtime establishes MainUI's 640x480 three-page layout in `init_system`, before the boot screen is drawn.

On a Miyoo Mini Flip the firmware leaves the framebuffer at 752x560 with three virtual pages before runtime starts:

```text
mode "752x560-77"
    geometry 752 560 752 1680 32
endmode
```

This was captured immediately after `init_lcd`, before any runtime mode change.

The boot-time transition is therefore a real pitch change, from 3008 bytes per row to 2560. The new 640x480 pages overlap memory previously used by the 752x560 layout, so this path preclears before changing geometry rather than allowing framebuffer contents written at the old stride to be scanned at the new one.

`launch_main_ui` then probes the framebuffer. If it is still 640x480/3, the layout is preserved and the boot screen remains visible until MainUI paints over it.

If the layout differs, runtime preclears before changing it so a pitch change cannot expose stale pixels written using the previous stride.

640-only devices do not use these extra preparation paths.

#### Shutdown

`keymon` can draw the `End_Save` screen while the game is still exiting. The screen is rendered using the framebuffer geometry it observed when it started, so changing the mode underneath it can shear the shutdown screen.

Runtime now preserves the framebuffer when `/tmp/.offOrder` is set. A normal return-to-MainUI transition is unnecessary once shutdown is already pending, so the current layout is left untouched.

### 2. Optional forced 640x480 mode

Adds an opt-in flag:

```text
$sysdir/config/.force640Res
```

When present, runtime pins `screen_resolution` to 640x480, removes `/tmp/new_res_available`, and establishes the 640x480 three-page framebuffer layout.

Removing `/tmp/new_res_available` is intentional: downstream code then takes the same paths it would on hardware that never exposed 560p, rather than every resolution-related call site needing a separate override case.

`/tmp/screen_resolution` records 640x480, so components that read it use the same geometry runtime is using. DraStic's `launch.sh` uses this file to decide whether to select its 752x560 mode, and `display_getResolution()` feeds `DISPLAY_WIDTH`/`DISPLAY_HEIGHT` for screenshot capture and GameSwitcher thumbnail scaling.

No flag file means no behavior change.

### 3. Installer framebuffer geometry

The installer starts outside Onion's normal runtime framebuffer setup.

`install.sh` runs `init_lcd` but does not establish a framebuffer geometry before its UI is used. `installUI` itself has a fixed 640x480 layout.

On a Flip, the framebuffer immediately after `init_lcd` was observed as:

```text
mode "752x560-77"
    geometry 752 560 752 1680 32
endmode
```

The installer now clears `/dev/fb0` and establishes a 640x480 two-page layout immediately after `init_lcd`, before any installer UI is drawn.

The clear deliberately happens first. `fbset` changes the framebuffer geometry but does not clear its contents, so pixels written using the firmware's 752x560 stride could otherwise be scanned using the new 640x480 stride until `installUI` produces its first frame.

Clearing the framebuffer allocation first means the geometry change operates on zeroed memory, applying the same preclear-before-pitch-change principle used by `fbmode` during runtime transitions.

This path uses `fbset` rather than `fbmode`. On a first install, `fbmode` is still inside `onion.pak`; on an update, the installer stub replaces the old `.tmp_update` contents before `install.sh` runs. The firmware-provided `fbset` is available during bootstrap, so the installer can establish its known 640x480 layout without depending on the Onion runtime helper.

This installer preparation runs on every device. On hardware already using 640x480 it clears the framebuffer and reapplies the geometry that is already active.

### Fallback

Runtime resolution-change paths retain their existing `fbset` fallback.

The runtime framebuffer preparation is gated on the presence of `fbmode`, and failed `fbmode` transitions fall back to `fbset` where a mode change is required. The installer uses firmware-provided `fbset` directly because `fbmode` is not available during bootstrap.

### Testing

Thanks @Amiga500 and "another.alvin" for testing and coming with feedback.

Tested on Miyoo Mini V4 / Miyoo Flip 752x560 hardware:

* repeated cold boots
* boot with and without `.force640Res`
* MainUI startup and return from games
* 640x480 and 752x560 game launches
* GameSwitcher handoffs and quick switching
* shutdown by power button from a 752x560 game
* repeated forced-640 boots to check for intermittent sheared output
* captured the firmware framebuffer geometry immediately after `init_lcd`
* first install on a 752x560 device
* first install on a 640x480 device
* verified behavior remains unchanged on Miyoo Mini Plus (640x480)