### PR TITLE
Clear `.forceKillRetroarch` before each launch

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -316,6 +316,7 @@ change_resolution() {
 
 launch_game() {
     log "\n:: Launch game"
+    rm -f /tmp/.forceKillRetroarch
     cmd=$(cat $sysdir/cmd_to_run.sh)
     TZ_VALUE=$(cat "$sysdir/config/.tz")
 
@@ -449,9 +450,15 @@ launch_game() {
 
     log "cmd retval: $retval"
 
+    forced_retroarch_kill=0
+    if [ -f /tmp/.forceKillRetroarch ]; then
+        forced_retroarch_kill=1
+        rm -f /tmp/.forceKillRetroarch
+    fi
+
     if [ $retval -eq 404 ]; then
         infoPanel --title "File not found" --message "The requested file was not found." --auto
-    elif [ $retval -ge 128 ] && [ $retval -ne 143 ] && [ $retval -ne 255 ] && [ ! -f /tmp/.forceKillRetroarch ]; then
+    elif [ $retval -ge 128 ] && [ $retval -ne 143 ] && [ $retval -ne 255 ] && [ $forced_retroarch_kill -eq 0 ]; then
         infoPanel --title "Fatal error occurred" --message "The program exited unexpectedly.\n(Error code: $retval)" --auto
     fi
 


### PR DESCRIPTION
### Problem

`/tmp/.forceKillRetroarch` tells runtime to skip the "Fatal error occurred" panel when we killed RetroArch deliberately. Nothing ever removed it.

So the first force-kill of a session leaves the flag on disk, and every genuine crash after that is silently swallowed for the rest of the session.

### What this does

Removes the flag at `launch_game` entry and reads it into a local before the `retval` checks, so it suppresses exactly the launch it was set for.
