### PR TITLE
Keep ROM list positions on the card

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -14,6 +14,7 @@ screen_resolution="640x480"
 
 romwinidx_device="/appconfigs/romwinidx.json"
 romwinidx_sd="$sysdir/config/romwinidx.json"
+romwinidx_dirty="$sysdir/config/.romwinidx_dirty"
 
 main() {
     # Set model ID based on hardware detection
@@ -663,12 +664,21 @@ launch_switcher() {
 }
 
 restore_romwinidx() {
-    if [ -f "$romwinidx_sd" ]; then
+    # save_romwinidx only runs from check_off_order, so the marker surviving a
+    # boot means the last session never reached a clean shutdown and the device
+    # file holds positions the card copy never received. Restoring would throw
+    # them away, so leave both files alone and let the next clean shutdown
+    # publish whatever the device has.
+    if [ -f "$romwinidx_dirty" ]; then
+        log "romwinidx: unclean shutdown, keeping device file"
+    elif [ -f "$romwinidx_sd" ]; then
         cp -f "$romwinidx_sd" "$romwinidx_device"
         log "romwinidx: restored from SD"
     else
         rm -f "$romwinidx_device"
     fi
+
+    touch "$romwinidx_dirty"
 }
 
 save_romwinidx() {
@@ -678,6 +688,7 @@ save_romwinidx() {
     else
         rm -f "$romwinidx_sd"
     fi
+    rm -f "$romwinidx_dirty"
     sync
 }
 

--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -12,6 +12,9 @@ MODEL_MMF=285
 MODEL_MMP=354
 screen_resolution="640x480"
 
+romwinidx_device="/appconfigs/romwinidx.json"
+romwinidx_sd="$sysdir/config/romwinidx.json"
+
 main() {
     # Set model ID based on hardware detection
     if [ -e /sys/devices/soc0/soc/soc:hall-mh248/hallvalue ] || [ -e /dev/input/event1 ]; then
@@ -37,6 +40,7 @@ main() {
     clear_logs
 
     init_system
+    restore_romwinidx
     update_time
 
     # Remount passwd/group to add our own users
@@ -658,9 +662,29 @@ launch_switcher() {
     sync
 }
 
+restore_romwinidx() {
+    if [ -f "$romwinidx_sd" ]; then
+        cp -f "$romwinidx_sd" "$romwinidx_device"
+        log "romwinidx: restored from SD"
+    else
+        rm -f "$romwinidx_device"
+    fi
+}
+
+save_romwinidx() {
+    if [ -f "$romwinidx_device" ]; then
+        cp -f "$romwinidx_device" "$romwinidx_sd"
+        log "romwinidx: saved to SD"
+    else
+        rm -f "$romwinidx_sd"
+    fi
+    sync
+}
+
 check_off_order() {
     if [ -f /tmp/.offOrder ]; then
         touch /tmp/shutting_down
+        save_romwinidx
 
         #EmuDeck - CheckOff scripts
         check_off_scripts=$(find "$sysdir/checkoff" -type f -name "*.sh")


### PR DESCRIPTION
### Problem

MainUI stores per-folder list positions in `/appconfigs/romwinidx.json`, which lives on internal storage. Move a card to another device, or reflash one, and every position is lost with no way to carry them across.

### What this does

Restores from `$sysdir/config/romwinidx.json` at boot and writes back on shutdown. If there is no copy on the card yet, the device file is removed, so the first boot after installing starts from a known state rather than inheriting whatever that device happened to have.

### Unclean shutdowns

The write-back happens in check_off_order, so it is skipped on a crash or power loss. Restoring unconditionally would then overwrite the device file with an older card copy. restore_romwinidx touches config/.romwinidx_dirty and save_romwinidx removes it, so a mark surviving a boot means the last session ended uncleanly - in that case neither file is touched.

Problem with unclean shutdowns reported by @Amiga500 and fixed in new commit.

### Known limitation

Positions from a session that ended uncleanly stay on the device and never reach the card, so they don't follow it to another device until the next clean shutdown.

### Testing

Moved a card between two devices and confirmed positions follow it.