### PR TITLE
Track icon reapply per device, not per card

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -46,12 +46,22 @@ main() {
     # Start the battery monitor
     batmon &
 
-    # Reapply theme
+    # Reapply theme when this SD is first used on a device.
     system_theme="$(/customer/app/jsonval theme)"
-    active_theme="$(cat $sysdir/config/active_theme)"
+    active_theme="$(cat "$sysdir/config/active_theme" 2>/dev/null)"
+    theme_device_state="$sysdir/config/theme-applied-$SERIAL_NUMBER"
+    applied_theme="$(cat "$theme_device_state" 2>/dev/null)"
 
-    if [ "$system_theme" == "./" ] || [ "$system_theme" != "$active_theme" ] || [ ! -d "$system_theme" ]; then
+    if [ "$system_theme" == "./" ] ||
+        [ "$system_theme" != "$active_theme" ] ||
+        [ ! -d "$system_theme" ] ||
+        [ "$applied_theme" != "$system_theme" ]; then
         themeSwitcher --reapply_icons
+
+        # Re-read: themeSwitcher writes the resolved theme back to settings,
+        # including when it falls back to a different one.
+        system_theme="$(/customer/app/jsonval theme)"
+        echo -n "$system_theme" > "$theme_device_state"
     fi
 
     # Check is charging


### PR DESCRIPTION
### Problem

The reapply check compares the system theme against `config/active_theme`, and both live on the SD card. A card whose icons were already applied on one device looks done on the next one, so you keep the first device's icons.

### What this does

Records the applied theme in `config/theme-applied-$SERIAL_NUMBER` and reapplies when it does not match. `SERIAL_NUMBER` already comes from `read_uuid` earlier in `main`, so no new dependency.

The theme is re-read from settings after the `themeSwitcher` call rather than reusing the value from before it. `installTheme` resolves the theme through `ensureThemePath` - named theme, then active theme, then default, then `/mnt/SDCARD/miyoo/app`, then `/customer/app` - and writes whatever it settled on back to `settings.json` and `config/active_theme`. Re-reading means the state file records the theme resolved in settings after the reapply, rather than the pre-call value, so a fallback does not get recorded as a successful apply of the requested theme.

Note that `themeSwitcher --reapply_icons` always exits 0 (`reinstallTheme` is `void` and `main` returns 0 unconditionally), so the exit code carries no information and is not tested. The re-read is what makes this correct.

### Cost

One extra `jsonval` call, and only on boots where a reapply actually runs.

### Testing

Same card booted on two devices; icons reapplied on the second, and the state file records the theme in use.