### PR TITLE
Cap recents at 200 when toggling hidden games

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -684,14 +684,14 @@ check_hide_recents() {
     if [ ! -f $sysdir/config/.showRecents ]; then
         # Hide recents by removing the json file
         if [ -f $recentlist ]; then
-            cat $recentlist $recentlist_hidden > $recentlist_temp
+            cat $recentlist $recentlist_hidden 2>/dev/null | head -n 200 > $recentlist_temp
             mv -f $recentlist_temp $recentlist_hidden
             rm -f $recentlist
         fi
     else
         # Restore recentlist
         if [ -f $recentlist_hidden ]; then
-            cat $recentlist $recentlist_hidden > $recentlist_temp
+            cat $recentlist $recentlist_hidden 2>/dev/null | head -n 200 > $recentlist_temp
             mv -f $recentlist_temp $recentlist
             rm -f $recentlist_hidden
         fi


### PR DESCRIPTION
### Problem

`recentlist` and `recentlist_hidden` get concatenated every time hidden games are toggled, and nothing trims the result, so it grows without bound.

### What this does

Caps the combined list at 200 entries in both the hide and unhide branches, and discards stderr so a missing hidden list is not reported as an error.