### PR TITLE
Stop repatching retroarch.cfg on every launch

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -459,7 +459,11 @@ launch_game() {
 }
 
 force_retroarch_cfg() {
-    # Enable network commands in RetroArch
+    ra_cfg=/mnt/SDCARD/RetroArch/.retroarch/retroarch.cfg
+    if grep -q '^[[:space:]]*network_cmd_enable[[:space:]]*=[[:space:]]*"true"[[:space:]]*$' "$ra_cfg" 2> /dev/null; then
+        return
+    fi
+
     cat > /tmp/onion_ra_patch.cfg <<- EOM
 network_cmd_enable = "true"
 EOM


### PR DESCRIPTION
### Problem

`force_retroarch_cfg` runs `patch_ra_cfg.sh` on every game launch, rewriting the config even when `network_cmd_enable` is already set.

### What this does

Checks for the setting first and returns early. The check still runs per launch, so if RetroArch rewrites its config on exit we repatch on the next one.