### PR TITLE
Shut the card down cleanly at the end of an install

### DIFF
--- a/static/dist/miyoo/app/.tmp_update/install.sh
+++ b/static/dist/miyoo/app/.tmp_update/install.sh
@@ -502,14 +502,33 @@ install_configs() {
     mv -f ./temp_keymap.json /mnt/SDCARD/.tmp_update/config/keymap.json
 }
 
+finalize_and_reboot() {
+    sync
+    cd /
+
+    # The installer chain all runs from the card, so install.sh cannot
+    # unmount it itself. bin/shutdown copies itself to /tmp and re-runs
+    # detached, which is what lets it kill the processes holding the mount
+    # and unmount cleanly. It exists once onion.pak has been extracted.
+    if [ -x /mnt/SDCARD/.tmp_update/bin/shutdown ]; then
+        /mnt/SDCARD/.tmp_update/bin/shutdown -r
+        sleep 10
+    fi
+
+    # Reached only before or during extraction, where far less has been
+    # written than a completed install.
+    umount -r /mnt/SDCARD 2> /dev/null
+    reboot
+    sleep 10
+}
+
 check_firmware() {
     echo ":: Check firmware"
     if [ ! -f /customer/lib/libpadsp.so ]; then
         cd $sysdir
         infoPanel -i "res/firmware.png"
         rm -rf $sysdir
-        reboot
-        sleep 10
+        finalize_and_reboot
         exit 0
     fi
 }
@@ -711,9 +730,7 @@ unzip_progress() {
     if [ "$extraction_status" -ne 0 ]; then
         touch $sysdir/.installFailed
         echo ":: Installation failed!"
-        sync
-        reboot
-        sleep 10
+        finalize_and_reboot
         exit 0
     else
         echo "$msg 100%" >> /tmp/.update_msg
@@ -728,6 +745,4 @@ free_mma() {
 }
 
 main
-sync
-reboot
-sleep 10
+finalize_and_reboot


### PR DESCRIPTION
### Problem

Every install leaves the SD card marked dirty, permanently.

`install.sh` ends with:

```sh
main
sync
reboot
```

`sync` writes back dirty data, but the volume stays mounted and writable. FAT carries a dirty flag that the kernel sets on a writable mount and clears on unmount or on the transition to read-only. Neither happens here, so the flag survives the reboot.

It then survives everything else too. From `fs/fat/inode.c`:

```c
/* do not change state if fs was dirty */
if (sbi->dirty) {
    /* warn only on set (mount). */
    if (set)
        fat_msg(sb, KERN_WARNING, "Volume was not properly "
            "unmounted. Some data may be corrupt. "
            "Please run fsck.");
    return;
}
```

`sbi->dirty` is loaded from the on-disk flag at mount time, and `fat_set_state()` deliberately refuses to touch a filesystem that was already dirty. So the flag is never cleared on a later unmount, however clean that unmount is. Booting into Onion and powering off properly through the menu does not help, and neither does doing it repeatedly.

The result is that any card which has been through an Onion install is flagged from that moment until the user runs a repair. Windows or macOS offers to repair it on every insert, and the repair reports no errors, because the filesystem is structurally fine.

### Why install.sh cannot unmount

The installer chain runs from the card and keeps files on the mount open, so /mnt/SDCARD can remain busy.

### Change

`bin/shutdown` already solves exactly this for normal power off. It copies itself to `/tmp`, re-runs detached from tmpfs so it is no longer on the card, kills `main`, `updater` and `runtime.sh` plus anything else `fuser` reports (skipping its own PID), then unmounts and reboots or powers off.

It is present on the card once `onion.pak` has been extracted, and `-r` selects reboot. So `finalize_and_reboot` uses it when available:

```sh
finalize_and_reboot() {
    sync
    cd /

    if [ -x /mnt/SDCARD/.tmp_update/bin/shutdown ]; then
        /mnt/SDCARD/.tmp_update/bin/shutdown -r
        sleep 10
    fi

    umount -r /mnt/SDCARD 2> /dev/null
    reboot
    sleep 10
}
```

The fallback covers the two exits that run before or during extraction: the firmware check, which happens before any files are written, and the extraction failure path, where the tree may be incomplete. Both write far less than a completed install.

Used at all three of `install.sh`'s exit points. `check_firmware` previously called `reboot` with no `sync` at all, and gains one.

No `swapoff` in the fallback, unlike `bin/shutdown`: the installer bootstrap bypasses `runtime.sh`'s swap setup and `install.sh` neither creates nor enables swap, so there is nothing to disable.

### Note for testing this

Because the flag is sticky, a card that has already been through an unpatched install will still be flagged no matter what this change does. Clear it with a repair first, or the patched install will look like it changed nothing.

### Testing

* repaired the card, installed with stock `install.sh`, re-checked - flagged again
* repaired the card, installed with the patch, re-checked - not flagged
* device reboots at the end of the install rather than returning to MainUI