### PR TITLE
Poll for the display driver at 100ms instead of 500ms

### DIFF
--- a/static/build/.tmp_update/runtime.sh
+++ b/static/build/.tmp_update/runtime.sh
@@ -725,19 +725,22 @@ mount_main_ui() {
 #   times out after 5 seconds, defaults to 640x480
 #
 get_screen_resolution() {
-    max_attempts=10
+    # Poll at 100ms rather than 500ms, keeping the same 5 second ceiling. The
+    # coarse interval could add almost half a second after the driver was
+    # already up. Log the total instead of each attempt: at this interval a
+    # per-attempt line would spawn date and tee up to 50 times per boot.
+    max_attempts=50
     attempt=0
 
     log "get_screen_resolution: start"
     while [ "$attempt" -lt "$max_attempts" ]; do
-        screen_resolution=$(grep 'Current TimingWidth=' /proc/mi_modules/fb/mi_fb0 | sed 's/Current TimingWidth=\([0-9]*\),TimingWidth=\([0-9]*\),.*/\1x\2/')
+        screen_resolution=$(grep 'Current TimingWidth=' /proc/mi_modules/fb/mi_fb0 2> /dev/null | sed 's/Current TimingWidth=\([0-9]*\),TimingWidth=\([0-9]*\),.*/\1x\2/')
         if [ -n "$screen_resolution" ]; then
-            log "get_screen_resolution: success, resolution: $screen_resolution"
+            log "get_screen_resolution: success after $attempt polls, resolution: $screen_resolution"
             break
         fi
-        log "get_screen_resolution: attempt $attempt failed"
         attempt=$((attempt + 1))
-        sleep 0.5
+        sleep 0.1
     done
 
     if [ -z "$screen_resolution" ]; then


### PR DESCRIPTION
### Problem

`get_screen_resolution` polls `/proc/mi_modules/fb/mi_fb0` every 500ms until the display driver publishes its timing. Once the driver is up, the coarse interval can add almost another half second before runtime notices.

### Change

Poll every 100ms with the same 5 second ceiling - 10 × 500ms and 50 × 100ms are identical, so the timeout path and `/tmp/get_screen_resolution_failed` behave exactly as before. Detection now lands within 100ms of the driver coming up.

The per-attempt log line becomes a poll count on success. At this interval it would otherwise fire up to 50 times per boot, and `log()` spawns `date` and `tee` each time. The grep gains `2> /dev/null` for the same reason - the file does not exist until the driver creates it, so every failed attempt wrote an error.

Independent of the framebuffer work in #1940, it touches only the polling loop.

### Testing

* repeated cold boots on Miyoo Flip, Miyoo Mini v4 and Miyoo Mini Plus
* poll count from the runtime log across those boots