### PR TITLE
Add PSX PBP metadata support to the Screenscraper scraper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ core: $(CACHE)/.setup
 	@cd $(SRC_DIR)/gameNameList && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/sendUDP && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/tree && BUILD_DIR=$(BIN_DIR) make
+	@cd $(SRC_DIR)/pbpinfo && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/pippi && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/cpuclock && BUILD_DIR=$(BIN_DIR) make
 

--- a/src/pbpinfo/Makefile
+++ b/src/pbpinfo/Makefile
@@ -1,0 +1,8 @@
+include ../common/config.mk
+
+TARGET = pbpinfo
+CFLAGS := $(CFLAGS)
+LDFLAGS := $(LDFLAGS)
+
+include ../common/commands.mk
+include ../common/recipes.mk

--- a/src/pbpinfo/pbpinfo.c
+++ b/src/pbpinfo/pbpinfo.c
@@ -1,0 +1,243 @@
+/*  The MIT License (MIT)
+ *
+ *  Copyright (c) 2026 OnionUI contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+// Reads a PlayStation EBOOT.PBP container: prints the game title and serial
+// id stored in the embedded PARAM.SFO, or extracts the embedded ICON0.PNG /
+// PIC1.PNG image. Used by the scraper to match PSX (PBP) games by their real
+// metadata instead of their filename.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PBP_MAGIC 0x50425000u // "\0PBP" as little-endian u32
+#define PBP_HEADER_SIZE 40
+#define SFO_HEADER_SIZE 20
+#define SFO_ENTRY_SIZE 16
+#define SFO_MAX_ENTRIES 256
+#define SFO_MAX_SIZE (1024 * 1024)
+#define PNG_SIG_SIZE 8
+
+static const uint8_t png_sig[PNG_SIG_SIZE] = {0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'};
+
+static uint16_t read_u16(const uint8_t *p) { return (uint16_t)(p[0] | (p[1] << 8)); }
+
+static uint32_t read_u32(const uint8_t *p)
+{
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint8_t *read_section(FILE *fh, uint32_t offset, uint32_t size, long file_size)
+{
+    uint8_t *data;
+
+    if (size == 0 || offset >= (uint32_t)file_size || size > SFO_MAX_SIZE)
+        return NULL;
+    if (offset > (uint32_t)file_size - size)
+        size = (uint32_t)file_size - offset;
+    data = malloc(size);
+    if (data == NULL)
+        return NULL;
+    if (fseek(fh, (long)offset, SEEK_SET) != 0 || fread(data, 1, size, fh) != size) {
+        free(data);
+        return NULL;
+    }
+    return data;
+}
+
+// Parses a PARAM.SFO buffer, calls cb(key, value, value_len) for each entry.
+// Returns 0 on success.
+static int sfo_parse(const uint8_t *sfo, uint32_t size,
+                     int (*cb)(const char *key, const char *value, uint32_t len, void *user), void *user)
+{
+    uint32_t key_start, data_start, count, i;
+
+    if (size < SFO_HEADER_SIZE || memcmp(sfo, "\0PSF", 4) != 0)
+        return -1;
+    key_start = read_u32(sfo + 8);
+    data_start = read_u32(sfo + 12);
+    count = read_u32(sfo + 16);
+    if (count > SFO_MAX_ENTRIES || key_start >= size || data_start > size || key_start < SFO_HEADER_SIZE)
+        return -1;
+
+    for (i = 0; i < count; i++) {
+        const uint8_t *entry = sfo + SFO_HEADER_SIZE + i * SFO_ENTRY_SIZE;
+        uint32_t key_off, data_len, data_off;
+        uint16_t fmt;
+        const char *key, *value;
+        uint32_t remaining;
+
+        if (SFO_HEADER_SIZE + (i + 1) * SFO_ENTRY_SIZE > size)
+            return -1;
+        key_off = read_u16(entry);
+        fmt = read_u16(entry + 2);
+        data_len = read_u32(entry + 4);
+        data_off = read_u32(entry + 12);
+
+        if (key_start + key_off >= size)
+            continue;
+        key = (const char *)sfo + key_start + key_off;
+        remaining = size - (key_start + key_off);
+        if (strnlen(key, remaining) == remaining)
+            continue; // unterminated key
+
+        if (fmt != 0x0204 && fmt != 0x0404)
+            continue; // only string entries are of interest here
+        if (data_off >= size || data_start > size - data_off)
+            continue;
+        if (data_start + data_off + data_len > size)
+            data_len = size - data_start - data_off;
+        value = (const char *)sfo + data_start + data_off;
+        if (cb(key, value, data_len, user) != 0)
+            return -1;
+    }
+    return 0;
+}
+
+static void sanitize(char *s, uint32_t len)
+{
+    uint32_t i;
+    for (i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (c == '\0') {
+            s[i] = '\0';
+            return;
+        }
+        if (c < 0x20 || c == 0x7f)
+            s[i] = ' ';
+    }
+    s[len] = '\0';
+}
+
+static int print_entry(const char *key, const char *value, uint32_t len, void *user)
+{
+    char clean[512];
+    uint32_t n = len < sizeof(clean) - 1 ? len : sizeof(clean) - 1;
+    (void)user;
+    if (strcmp(key, "TITLE") != 0 && strcmp(key, "DISC_ID") != 0 && strcmp(key, "TITLE_ID") != 0)
+        return 0;
+    memcpy(clean, value, n);
+    clean[n] = '\0';
+    sanitize(clean, n);
+    if (clean[0] == '\0')
+        return 0;
+    printf("%s=%s\n", key, clean);
+    return 0;
+}
+
+static int extract_image(const char *pbp_path, int index, const char *out_path)
+{
+    FILE *fh = fopen(pbp_path, "rb");
+    uint8_t header[PBP_HEADER_SIZE];
+    uint32_t offsets[8], start, size;
+    long file_size;
+    uint8_t *data;
+    FILE *out;
+    int ok = 0;
+
+    if (fh == NULL)
+        return 1;
+    if (fseek(fh, 0, SEEK_END) != 0 || (file_size = ftell(fh)) < 0)
+        goto fail;
+    if (fseek(fh, 0, SEEK_SET) != 0 || fread(header, 1, PBP_HEADER_SIZE, fh) != PBP_HEADER_SIZE ||
+        read_u32(header) != PBP_MAGIC)
+        goto fail;
+
+    for (int i = 0; i < 8; i++)
+        offsets[i] = read_u32(header + 8 + i * 4);
+    start = offsets[index];
+    size = (index < 7 && offsets[index + 1] > start) ? offsets[index + 1] - start
+                                                     : (uint32_t)file_size - start;
+    if (start == 0 || size < PNG_SIG_SIZE)
+        goto fail;
+    data = read_section(fh, start, size, file_size);
+    if (data == NULL)
+        goto fail;
+    if (memcmp(data, png_sig, PNG_SIG_SIZE) != 0) {
+        free(data);
+        goto fail;
+    }
+
+    out = fopen(out_path, "wb");
+    if (out == NULL) {
+        free(data);
+        goto fail;
+    }
+    ok = fwrite(data, 1, size, out) == size;
+    fclose(out);
+    free(data);
+
+fail:
+    fclose(fh);
+    return ok ? 0 : 1;
+}
+
+int main(int argc, char *argv[])
+{
+    FILE *fh;
+    uint8_t header[PBP_HEADER_SIZE];
+    uint32_t offsets[8], sfo_size;
+    uint8_t *sfo;
+    long file_size;
+
+    if (argc == 4 && (strcmp(argv[1], "-i") == 0 || strcmp(argv[1], "-p") == 0))
+        return extract_image(argv[2], argv[1][1] == 'i' ? 1 : 4, argv[3]);
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: pbpinfo <file.pbp>\n"
+                        "       pbpinfo -i <file.pbp> <out.png>  (extract ICON0.PNG)\n"
+                        "       pbpinfo -p <file.pbp> <out.png>  (extract PIC1.PNG)\n");
+        return 2;
+    }
+
+    fh = fopen(argv[1], "rb");
+    if (fh == NULL) {
+        fprintf(stderr, "pbpinfo: cannot open %s\n", argv[1]);
+        return 1;
+    }
+    if (fseek(fh, 0, SEEK_END) != 0 || (file_size = ftell(fh)) < 0 ||
+        fseek(fh, 0, SEEK_SET) != 0) {
+        fclose(fh);
+        return 1;
+    }
+    if (file_size < PBP_HEADER_SIZE || fread(header, 1, PBP_HEADER_SIZE, fh) != PBP_HEADER_SIZE ||
+        read_u32(header) != PBP_MAGIC) {
+        fprintf(stderr, "pbpinfo: %s is not a PBP file\n", argv[1]);
+        fclose(fh);
+        return 1;
+    }
+
+    for (int i = 0; i < 8; i++)
+        offsets[i] = read_u32(header + 8 + i * 4);
+    sfo_size = (offsets[0] && offsets[1] > offsets[0]) ? offsets[1] - offsets[0] : 0;
+    sfo = sfo_size ? read_section(fh, offsets[0], sfo_size, file_size) : NULL;
+    fclose(fh);
+    if (sfo == NULL || sfo_parse(sfo, sfo_size, print_entry, NULL) != 0) {
+        free(sfo);
+        fprintf(stderr, "pbpinfo: no PARAM.SFO metadata in %s\n", argv[1]);
+        return 1;
+    }
+    free(sfo);
+    return 0;
+}

--- a/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
@@ -403,14 +403,32 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
     # Cleaning up names
     romName=$(basename "$file")
     romNameNoExtension=${romName%.*}
-	echo $romNameNoExtension	
-    
+	echo $romNameNoExtension
+
+    # PBP (EBOOT) files : extract real title and serial from the embedded PARAM.SFO
+    isPbp=0
+    pbpTitle=""
+    pbpSerial=""
+    case "$(echo "$romName" | tr '[:upper:]' '[:lower:]')" in
+    *.pbp)
+        isPbp=1
+        if pbpMetadata=$(pbpinfo "$file" 2>/dev/null); then
+            pbpTitle=$(echo "$pbpMetadata" | sed -n 's/^TITLE=//p')
+            pbpSerial=$(echo "$pbpMetadata" | sed -n 's/^DISC_ID=//p')
+            [ -n "$pbpSerial" ] && echo "PBP serial : $pbpSerial"
+            [ -n "$pbpTitle" ] && echo "PBP title  : $pbpTitle"
+        else
+            echo -e "${YELLOW}could not read PBP metadata, falling back to file name${NONE}"
+        fi
+        ;;
+    esac
+
     romNameTrimmed="${romNameNoExtension/".nkit"/}"
     romNameTrimmed="${romNameTrimmed//"!"/}"
     romNameTrimmed="${romNameTrimmed//"&"/}"
     romNameTrimmed="${romNameTrimmed/"Disc "/}"
     romNameTrimmed="${romNameTrimmed/"Rev "/}"
-    romNameTrimmed="$(echo "$romNameTrimmed" | sed -e 's/ ([^()]*)//g' -e 's/ [[A-z0-9!+]*]//g' -e 's/([^()]*)//g' -e 's/[[A-z0-9!+]*]//g')"
+    romNameTrimmed="$(echo "$romNameTrimmed" | sed -e 's/ ([^()]*)//g' -e 's/ [[A-z0-9!+-]*]//g' -e 's/([^()]*)//g' -e 's/[[A-z0-9!+-]*]//g')"
     romNameTrimmed="${romNameTrimmed//" - "/"%20"}"
     romNameTrimmed="${romNameTrimmed/"-"/"%20"}"
     romNameTrimmed="${romNameTrimmed//" "/"%20"}"
@@ -425,37 +443,71 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
 	
 	else
 		rom_size=$(stat -c%s "$file")
-		url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=&systemeid=${ssSystemID}&romtype=rom&romnom=${romNameTrimmed}.zip&romtaille=${rom_size}"
-    	search_on_screenscraper
-    	
-    	# Don't check art if we didn't get screenscraper game ID
-        if ! [ "$gameIDSS" -eq "$gameIDSS" ] 2> /dev/null; then
+
+		# --- 1) PBP : exact search by serial number (from the embedded PARAM.SFO) ---
+		if [ -n "$pbpSerial" ]; then
+			pbpSerialDashed=$(echo "$pbpSerial" | sed -e 's/^\(.\{4\}\)\([0-9A-Z]\{3,6\}\)$/\1-\2/')
+			echo "Searching by serial : $pbpSerialDashed"
+			url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=&systemeid=${ssSystemID}&romtype=rom&romnom=${pbpSerialDashed}.zip&romtaille=${rom_size}&ssserial=${pbpSerialDashed}"
+			search_on_screenscraper
+		fi
+
+		# --- 2) PBP : search by the real game title (from the embedded PARAM.SFO) ---
+		if [ -z "$gameIDSS" ] && [ -n "$pbpTitle" ]; then
+			pbpTitleTrimmed="$(echo "$pbpTitle" | sed -e 's/ ([^()]*)//g' -e 's/ [[A-z0-9!+-]*]//g' -e 's/([^()]*)//g' -e 's/[[A-z0-9!+-]*]//g' -e 's/^ *//' -e 's/ *$//')"
+			pbpTitleTrimmed="${pbpTitleTrimmed//" - "/"%20"}"
+			pbpTitleTrimmed="${pbpTitleTrimmed/"-"/"%20"}"
+			pbpTitleTrimmed="${pbpTitleTrimmed//" "/"%20"}"
+			url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=&systemeid=${ssSystemID}&romtype=rom&romnom=${pbpTitleTrimmed}.zip&romtaille=${rom_size}"
+			search_on_screenscraper
+		fi
+
+		# --- 3) search by file name (skipped when a PBP title was already tried) ---
+		if [ -z "$gameIDSS" ] && { [ "$isPbp" != "1" ] || [ -z "$pbpTitle" ]; }; then
+			url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=&systemeid=${ssSystemID}&romtype=rom&romnom=${romNameTrimmed}.zip&romtaille=${rom_size}"
+			search_on_screenscraper
+		fi
+
+		# --- 4) last chance : rom checksum (pointless for PBP containers, skip them) ---
+		if [ -z "$gameIDSS" ] && [ "$isPbp" != "1" ]; then
 			# Last chance : we search thanks to rom checksum
 			MAX_FILE_SIZE_BYTES=52428800  #50MB
-			
+
 			if [ "$rom_size" -gt "$MAX_FILE_SIZE_BYTES" ]; then
 				echo -e "${RED}Rom is too big to make a checksum.${NONE}"
 				let Scrap_Fail++;
 				continue;
-				
+
 			else
 				echo -n "CRC check..."
 				CRC=$(xcrc "$file")
 				echo " $CRC"
 				# !!! systemid must not be specified, it impacts the search by CRC but not romtaille (must be > 2 however) or romnom. Most of other parameters than CRC are useless for the request but helps to fill SS database
-				url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=${CRC}&systemeid=&romtype=rom&romnom=${romNameTrimmed}.zip&romtaille=${rom_size}"  
+				url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=${CRC}&systemeid=&romtype=rom&romnom=${romNameTrimmed}.zip&romtaille=${rom_size}"
 				search_on_screenscraper
-				if ! [ "$gameIDSS" -eq "$gameIDSS" ] 2> /dev/null; then	
+				if [ -z "$gameIDSS" ]; then
 					echo -e "${RED}Failed to get game ID${NONE}"
 					let Scrap_Fail++;
 					continue;
 				fi
-				
+
 				RealgameName=$(echo "$api_result" | jq -r '.response.jeu.noms[0].text')
 				echo Real name found : "$RealgameName"
 			fi
+		fi
 
-        fi
+		# --- 5) PBP with no Screenscraper match : use the icon embedded in the file ---
+		if [ "$isPbp" = "1" ] && [ -z "$gameIDSS" ]; then
+			echo -n "No Screenscraper match, trying the PBP embedded icon... "
+			if pbpinfo -i "$file" "/mnt/SDCARD/Roms/$CurrentSystem/Imgs/$romNameNoExtension.png" 2>/dev/null; then
+				echo -e "${GREEN}Scraped from PBP metadata !${NONE}"
+				let Scrap_Success++;
+			else
+				echo -e "${RED}no embedded icon found${NONE}"
+				let Scrap_Fail++;
+			fi
+			continue;
+		fi
 		
         echo "gameID = $gameIDSS"
 


### PR DESCRIPTION
## Problem

PSX games stored as PBP (EBOOT.PBP) containers are effectively unscrapeable: the scraper derives its search term from the file name, so `colin.pbp`, `gran_turismo_2_sim.pbp` or per-game folders with `EBOOT.PBP` produce garbage queries, and the CRC fallback can never match (a PBP container's checksum isn't in the database, and large files are skipped anyway). Result: no boxart for those games.

Meanwhile every PSN-style PBP embeds a `PARAM.SFO` with the real game title and serial id.

## Solution

New small tool `src/pbpinfo` (pure stdio C, no new dependencies) reads a PBP container:

- `pbpinfo <file.pbp>` prints `TITLE=` / `DISC_ID=` from the embedded PARAM.SFO
- `pbpinfo -i|-p <file.pbp> <out.png>` extracts the embedded `ICON0.PNG` / `PIC1.PNG`

`scrap_screenscraper.sh` uses it to build a search cascade for `*.pbp` files only:

1. exact search by serial number (`SLES02906` → `SLES-02906`) via `ssserial`
2. name search using the real SFO title (region/decoration tags trimmed, URL-encoded)
3. name search by file name (previous behavior, skipped when 2 already ran)
4. CRC checksum search (unchanged for other formats; skipped for PBP, where it's pointless)
5. last resort: extract the embedded `ICON0.PNG` as boxart, so a PBP gets art even with no Screenscraper match (works offline)

The flow for every non-PBP file is unchanged (same requests, same order).

Bonus fix while touching the trimming code: the bracket-stripping `sed` didn't handle `-` inside tags, so filenames/titles with `[NTSC-J]`, `[NTSC-U]` etc. were mangled into queries like `Tekken%203%20[NTSC%20` — affects all systems, not just PSX.

## Testing

- `pbpinfo` verified against 18 real PSN PSX classics (all expose `TITLE` + `DISC_ID`; icon extraction validated)
- Full flow device-tested on a Miyoo Mini: serial/title search, boxart download, and embedded-icon fallback all work
- Cross-compiled clean with the official toolchain; `clang-format` and `cppcheck --enable=all` clean

## Notes

- `ssserial` is my best reading of the API docs for serial search; if Screenscraper ignores it, the cascade simply falls through to the title search (still a strict improvement over the current state). Happy to adjust the parameter name if a maintainer knows better.
- PBP files in per-game subfolders write their image to the system-level `Imgs/` folder (existing scraper convention), so multi-game `EBOOT.PBP` folder layouts are out of scope here.
