### PR TITLE
Add option to discard embedded PBP art when scraping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ core: $(CACHE)/.setup
 	@cd $(SRC_DIR)/gameNameList && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/sendUDP && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/tree && BUILD_DIR=$(BIN_DIR) make
+	@cd $(SRC_DIR)/pbpinfo && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/pippi && BUILD_DIR=$(BIN_DIR) make
 	@cd $(SRC_DIR)/cpuclock && BUILD_DIR=$(BIN_DIR) make
 

--- a/src/pbpinfo/Makefile
+++ b/src/pbpinfo/Makefile
@@ -1,0 +1,8 @@
+include ../common/config.mk
+
+TARGET = pbpinfo
+CFLAGS := $(CFLAGS)
+LDFLAGS := $(LDFLAGS)
+
+include ../common/commands.mk
+include ../common/recipes.mk

--- a/src/pbpinfo/pbpinfo.c
+++ b/src/pbpinfo/pbpinfo.c
@@ -1,0 +1,243 @@
+/*  The MIT License (MIT)
+ *
+ *  Copyright (c) 2026 OnionUI contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+// Reads a PlayStation EBOOT.PBP container: prints the game title and serial
+// id stored in the embedded PARAM.SFO, or extracts the embedded ICON0.PNG /
+// PIC1.PNG image. Used by the scraper to match PSX (PBP) games by their real
+// metadata instead of their filename.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PBP_MAGIC 0x50425000u // "\0PBP" as little-endian u32
+#define PBP_HEADER_SIZE 40
+#define SFO_HEADER_SIZE 20
+#define SFO_ENTRY_SIZE 16
+#define SFO_MAX_ENTRIES 256
+#define SFO_MAX_SIZE (1024 * 1024)
+#define PNG_SIG_SIZE 8
+
+static const uint8_t png_sig[PNG_SIG_SIZE] = {0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'};
+
+static uint16_t read_u16(const uint8_t *p) { return (uint16_t)(p[0] | (p[1] << 8)); }
+
+static uint32_t read_u32(const uint8_t *p)
+{
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint8_t *read_section(FILE *fh, uint32_t offset, uint32_t size, long file_size)
+{
+    uint8_t *data;
+
+    if (size == 0 || offset >= (uint32_t)file_size || size > SFO_MAX_SIZE)
+        return NULL;
+    if (offset > (uint32_t)file_size - size)
+        size = (uint32_t)file_size - offset;
+    data = malloc(size);
+    if (data == NULL)
+        return NULL;
+    if (fseek(fh, (long)offset, SEEK_SET) != 0 || fread(data, 1, size, fh) != size) {
+        free(data);
+        return NULL;
+    }
+    return data;
+}
+
+// Parses a PARAM.SFO buffer, calls cb(key, value, value_len) for each entry.
+// Returns 0 on success.
+static int sfo_parse(const uint8_t *sfo, uint32_t size,
+                     int (*cb)(const char *key, const char *value, uint32_t len, void *user), void *user)
+{
+    uint32_t key_start, data_start, count, i;
+
+    if (size < SFO_HEADER_SIZE || memcmp(sfo, "\0PSF", 4) != 0)
+        return -1;
+    key_start = read_u32(sfo + 8);
+    data_start = read_u32(sfo + 12);
+    count = read_u32(sfo + 16);
+    if (count > SFO_MAX_ENTRIES || key_start >= size || data_start > size || key_start < SFO_HEADER_SIZE)
+        return -1;
+
+    for (i = 0; i < count; i++) {
+        const uint8_t *entry = sfo + SFO_HEADER_SIZE + i * SFO_ENTRY_SIZE;
+        uint32_t key_off, data_len, data_off;
+        uint16_t fmt;
+        const char *key, *value;
+        uint32_t remaining;
+
+        if (SFO_HEADER_SIZE + (i + 1) * SFO_ENTRY_SIZE > size)
+            return -1;
+        key_off = read_u16(entry);
+        fmt = read_u16(entry + 2);
+        data_len = read_u32(entry + 4);
+        data_off = read_u32(entry + 12);
+
+        if (key_start + key_off >= size)
+            continue;
+        key = (const char *)sfo + key_start + key_off;
+        remaining = size - (key_start + key_off);
+        if (strnlen(key, remaining) == remaining)
+            continue; // unterminated key
+
+        if (fmt != 0x0204 && fmt != 0x0404)
+            continue; // only string entries are of interest here
+        if (data_off >= size || data_start > size - data_off)
+            continue;
+        if (data_start + data_off + data_len > size)
+            data_len = size - data_start - data_off;
+        value = (const char *)sfo + data_start + data_off;
+        if (cb(key, value, data_len, user) != 0)
+            return -1;
+    }
+    return 0;
+}
+
+static void sanitize(char *s, uint32_t len)
+{
+    uint32_t i;
+    for (i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (c == '\0') {
+            s[i] = '\0';
+            return;
+        }
+        if (c < 0x20 || c == 0x7f)
+            s[i] = ' ';
+    }
+    s[len] = '\0';
+}
+
+static int print_entry(const char *key, const char *value, uint32_t len, void *user)
+{
+    char clean[512];
+    uint32_t n = len < sizeof(clean) - 1 ? len : sizeof(clean) - 1;
+    (void)user;
+    if (strcmp(key, "TITLE") != 0 && strcmp(key, "DISC_ID") != 0 && strcmp(key, "TITLE_ID") != 0)
+        return 0;
+    memcpy(clean, value, n);
+    clean[n] = '\0';
+    sanitize(clean, n);
+    if (clean[0] == '\0')
+        return 0;
+    printf("%s=%s\n", key, clean);
+    return 0;
+}
+
+static int extract_image(const char *pbp_path, int index, const char *out_path)
+{
+    FILE *fh = fopen(pbp_path, "rb");
+    uint8_t header[PBP_HEADER_SIZE];
+    uint32_t offsets[8], start, size;
+    long file_size;
+    uint8_t *data;
+    FILE *out;
+    int ok = 0;
+
+    if (fh == NULL)
+        return 1;
+    if (fseek(fh, 0, SEEK_END) != 0 || (file_size = ftell(fh)) < 0)
+        goto fail;
+    if (fseek(fh, 0, SEEK_SET) != 0 || fread(header, 1, PBP_HEADER_SIZE, fh) != PBP_HEADER_SIZE ||
+        read_u32(header) != PBP_MAGIC)
+        goto fail;
+
+    for (int i = 0; i < 8; i++)
+        offsets[i] = read_u32(header + 8 + i * 4);
+    start = offsets[index];
+    size = (index < 7 && offsets[index + 1] > start) ? offsets[index + 1] - start
+                                                     : (uint32_t)file_size - start;
+    if (start == 0 || size < PNG_SIG_SIZE)
+        goto fail;
+    data = read_section(fh, start, size, file_size);
+    if (data == NULL)
+        goto fail;
+    if (memcmp(data, png_sig, PNG_SIG_SIZE) != 0) {
+        free(data);
+        goto fail;
+    }
+
+    out = fopen(out_path, "wb");
+    if (out == NULL) {
+        free(data);
+        goto fail;
+    }
+    ok = fwrite(data, 1, size, out) == size;
+    fclose(out);
+    free(data);
+
+fail:
+    fclose(fh);
+    return ok ? 0 : 1;
+}
+
+int main(int argc, char *argv[])
+{
+    FILE *fh;
+    uint8_t header[PBP_HEADER_SIZE];
+    uint32_t offsets[8], sfo_size;
+    uint8_t *sfo;
+    long file_size;
+
+    if (argc == 4 && (strcmp(argv[1], "-i") == 0 || strcmp(argv[1], "-p") == 0))
+        return extract_image(argv[2], argv[1][1] == 'i' ? 1 : 4, argv[3]);
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: pbpinfo <file.pbp>\n"
+                        "       pbpinfo -i <file.pbp> <out.png>  (extract ICON0.PNG)\n"
+                        "       pbpinfo -p <file.pbp> <out.png>  (extract PIC1.PNG)\n");
+        return 2;
+    }
+
+    fh = fopen(argv[1], "rb");
+    if (fh == NULL) {
+        fprintf(stderr, "pbpinfo: cannot open %s\n", argv[1]);
+        return 1;
+    }
+    if (fseek(fh, 0, SEEK_END) != 0 || (file_size = ftell(fh)) < 0 ||
+        fseek(fh, 0, SEEK_SET) != 0) {
+        fclose(fh);
+        return 1;
+    }
+    if (file_size < PBP_HEADER_SIZE || fread(header, 1, PBP_HEADER_SIZE, fh) != PBP_HEADER_SIZE ||
+        read_u32(header) != PBP_MAGIC) {
+        fprintf(stderr, "pbpinfo: %s is not a PBP file\n", argv[1]);
+        fclose(fh);
+        return 1;
+    }
+
+    for (int i = 0; i < 8; i++)
+        offsets[i] = read_u32(header + 8 + i * 4);
+    sfo_size = (offsets[0] && offsets[1] > offsets[0]) ? offsets[1] - offsets[0] : 0;
+    sfo = sfo_size ? read_section(fh, offsets[0], sfo_size, file_size) : NULL;
+    fclose(fh);
+    if (sfo == NULL || sfo_parse(sfo, sfo_size, print_entry, NULL) != 0) {
+        free(sfo);
+        fprintf(stderr, "pbpinfo: no PARAM.SFO metadata in %s\n", argv[1]);
+        return 1;
+    }
+    free(sfo);
+    return 0;
+}

--- a/static/build/.tmp_update/script/scraper/config_repair.sh
+++ b/static/build/.tmp_update/script/scraper/config_repair.sh
@@ -19,6 +19,7 @@ if [ -z "$config_json" ] || ! echo "$config_json" | jq . >/dev/null 2>&1; then
       "Screenscraper_enabled": "true",
       "Launchbox_enabled": "true",
       "ScrapeInBackground": "false",
+      "DiscardEmbeddedArt": "true",
       "RetroarchMediaType": "Named_Boxarts",
       "ScreenscraperMediaType": "box-2D",
       "LaunchboxMediaType": "Box - Front",
@@ -34,6 +35,7 @@ updated_config_json=$(echo "$config_json" | jq 'if .screenscraper_username == nu
     | if .Screenscraper_enabled == null then .Screenscraper_enabled = "true" else . end
     | if .Launchbox_enabled == null then .Launchbox_enabled = "true" else . end
     | if .ScrapeInBackground == null then .ScrapeInBackground = "false" else . end
+    | if .DiscardEmbeddedArt == null then .DiscardEmbeddedArt = "true" else . end
     | if .RetroarchMediaType == null then .RetroarchMediaType = "Named_Boxarts" else . end
     | if .ScreenscraperMediaType == null then .ScreenscraperMediaType = "box-2D" else . end
     | if .LaunchboxMediaType == null then .LaunchboxMediaType = "Box - Front" else . end

--- a/static/build/.tmp_update/script/scraper/menu.sh
+++ b/static/build/.tmp_update/script/scraper/menu.sh
@@ -32,16 +32,18 @@ Menu_Config()
 	Option3="Scraping sources"
     Option4="Screenscraper: account settings"
     Option5="Toggle background scraping"
-    Option6="Back to Main Menu"
-    
-    Mychoice=$( echo -e "$Option1\n$Option2\n$Option3\n$Option4\n$Option5\n$Option6" | /mnt/SDCARD/.tmp_update/script/shellect.sh -t "      --== CONFIGURATION MENU ==--" -b "Press A to validate your choice.")
+    Option6="Toggle discard of embedded PBP art"
+    Option7="Back to Main Menu"
+
+    Mychoice=$( echo -e "$Option1\n$Option2\n$Option3\n$Option4\n$Option5\n$Option6\n$Option7" | /mnt/SDCARD/.tmp_update/script/shellect.sh -t "      --== CONFIGURATION MENU ==--" -b "Press A to validate your choice.")
 
     [ "$Mychoice" = "$Option1" ] && Menu_Config_MediaType
     [ "$Mychoice" = "$Option2" ] && Menu_RegionSelection
     [ "$Mychoice" = "$Option3" ] && Menu_Config_ScrapingSource
     [ "$Mychoice" = "$Option4" ] && Menu_Config_SSAccountSettings
     [ "$Mychoice" = "$Option5" ] && Menu_Config_BackgroundScraping
-	[ "$Mychoice" = "$Option6" ] && Menu_Main
+    [ "$Mychoice" = "$Option6" ] && Menu_Config_DiscardEmbedded
+	[ "$Mychoice" = "$Option7" ] && Menu_Main
 	
 	sync
 }
@@ -231,6 +233,47 @@ Menu_Config_BackgroundScraping()
 
         config=$(cat $ScraperConfigFile)
         config=$(echo "$config" | jq --arg ScrapeInBackground "$ScrapeInBackground" '.ScrapeInBackground = $ScrapeInBackground')
+        echo "$config" > $ScraperConfigFile
+        sync
+        Menu_Config
+}
+
+
+##########################################################################################
+
+Menu_Config_DiscardEmbedded()
+{
+    # Check if the configuration file exists
+    if [ ! -f "$ScraperConfigFile" ]; then
+      echo "Error: configuration file not found"
+      read -n 1 -s -r -p "Press A to continue"
+      exit 1
+    fi
+
+    clear
+    echo -e "====================================================\n\n"
+    echo -e "PSX games in PBP format contain a small icon\nextracted locally as a fallback artwork.\n\nWith this option ON, scraping Screenscraper will\ndiscard it and download higher quality boxart.\n\nArt fetched by a scraper is never discarded.\n"
+    echo -e "====================================================\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
+    read -n 1 -s -r -p "Press A to continue"
+    clear
+
+    config=$(cat "$ScraperConfigFile")
+    DiscardEmbeddedArt=$(echo "$config" | jq -r '.DiscardEmbeddedArt')
+
+
+    	Mychoice=$( echo -e "No\nYes\nBack to Configuration Menu" | /mnt/SDCARD/.tmp_update/script/shellect.sh -t "Discard embedded PBP art ? (Currently: $DiscardEmbeddedArt)" -b "Press A to validate your choice.")
+
+        if [ "$Mychoice" = "Yes" ]; then
+            DiscardEmbeddedArt="true"
+        elif [ "$Mychoice" = "No" ]; then
+            DiscardEmbeddedArt="false"
+		elif [ "$Mychoice" = "Back to Configuration Menu" ]; then
+			Menu_Config
+			return
+        fi
+
+        config=$(cat $ScraperConfigFile)
+        config=$(echo "$config" | jq --arg DiscardEmbeddedArt "$DiscardEmbeddedArt" '.DiscardEmbeddedArt = $DiscardEmbeddedArt')
         echo "$config" > $ScraperConfigFile
         sync
         Menu_Config

--- a/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
@@ -277,6 +277,7 @@ if [ -f "$ScraperConfigFile" ]; then
     userSS=$(echo "$config" | jq -r '.screenscraper_username')
     passSS=$(echo "$config" | jq -r '.screenscraper_password')
     ScrapeInBackground=$(echo "$config" | jq -r '.ScrapeInBackground')
+    DiscardEmbeddedArt=$(echo "$config" | jq -r '.DiscardEmbeddedArt')
 	u=$(echo "U2FsdGVkX18PKpoEvELyE+5xionDX8iRxAIxJj4FN1U=" | openssl enc -aes-256-cbc -d -a -pbkdf2 -iter 10000 -salt -pass pass:"3x0tVD3jZvElZWRt3V67QQ==")
 	p=$(echo "U2FsdGVkX1/ydn2FWrwYcFVc5gVYgc5kVaJ5jDOeOKE=" |openssl enc -aes-256-cbc -d -a -pbkdf2 -iter 10000 -salt -pass pass:"RuA29ch3zVoodAItmvKKmZ+4Au+5owgvV/ztqRu4NjI=")
 	# Regions order management
@@ -296,6 +297,11 @@ EOF
     fi
 fi
 
+# discard embedded PBP art on scrape unless explicitly disabled
+[ "$DiscardEmbeddedArt" = "false" ] || DiscardEmbeddedArt="true"
+
+# registry of roms whose artwork was extracted locally from PBP internals
+localArtList="/mnt/SDCARD/Roms/$CurrentSystem/Imgs/.pbp_local_art.txt"
 
 
 # TODO : improve or remove this part (now in options)
@@ -437,6 +443,15 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
     #echo $romNameTrimmed # for debugging
 
 
+	# Discard locally extracted PBP art so Screenscraper boxart can be downloaded instead
+	if [ "$isPbp" = "1" ] && [ "$DiscardEmbeddedArt" != "false" ] && \
+	   [ -f "/mnt/SDCARD/Roms/$CurrentSystem/Imgs/$romNameNoExtension.png" ] && \
+	   grep -qxF "$romNameNoExtension" "$localArtList" 2>/dev/null; then
+		echo -e "${YELLOW}discarding embedded PBP art, fetching higher quality boxart${NONE}"
+		rm -f "/mnt/SDCARD/Roms/$CurrentSystem/Imgs/$romNameNoExtension.png"
+		grep -Fxv "$romNameNoExtension" "$localArtList" > "$localArtList.tmp" 2>/dev/null && mv "$localArtList.tmp" "$localArtList"
+	fi
+
 	if [ -f "/mnt/SDCARD/Roms/$CurrentSystem/Imgs/$romNameNoExtension.png" ]; then
 		echo -e "${YELLOW}already Scraped !${NONE}"
 		let Scrap_notrequired++;
@@ -501,6 +516,7 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
 			echo -n "No Screenscraper match, trying the PBP embedded icon... "
 			if pbpinfo -i "$file" "/mnt/SDCARD/Roms/$CurrentSystem/Imgs/$romNameNoExtension.png" 2>/dev/null; then
 				echo -e "${GREEN}Scraped from PBP metadata !${NONE}"
+				echo "$romNameNoExtension" >> "$localArtList"
 				let Scrap_Success++;
 			else
 				echo -e "${RED}no embedded icon found${NONE}"

--- a/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
+++ b/static/build/.tmp_update/script/scraper/scrap_screenscraper.sh
@@ -403,14 +403,32 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
     # Cleaning up names
     romName=$(basename "$file")
     romNameNoExtension=${romName%.*}
-	echo $romNameNoExtension	
-    
+	echo $romNameNoExtension
+
+    # PBP (EBOOT) files : extract real title and serial from the embedded PARAM.SFO
+    isPbp=0
+    pbpTitle=""
+    pbpSerial=""
+    case "$(echo "$romName" | tr '[:upper:]' '[:lower:]')" in
+    *.pbp)
+        isPbp=1
+        if pbpMetadata=$(pbpinfo "$file" 2>/dev/null); then
+            pbpTitle=$(echo "$pbpMetadata" | sed -n 's/^TITLE=//p')
+            pbpSerial=$(echo "$pbpMetadata" | sed -n 's/^DISC_ID=//p')
+            [ -n "$pbpSerial" ] && echo "PBP serial : $pbpSerial"
+            [ -n "$pbpTitle" ] && echo "PBP title  : $pbpTitle"
+        else
+            echo -e "${YELLOW}could not read PBP metadata, falling back to file name${NONE}"
+        fi
+        ;;
+    esac
+
     romNameTrimmed="${romNameNoExtension/".nkit"/}"
     romNameTrimmed="${romNameTrimmed//"!"/}"
     romNameTrimmed="${romNameTrimmed//"&"/}"
     romNameTrimmed="${romNameTrimmed/"Disc "/}"
     romNameTrimmed="${romNameTrimmed/"Rev "/}"
-    romNameTrimmed="$(echo "$romNameTrimmed" | sed -e 's/ ([^()]*)//g' -e 's/ [[A-z0-9!+]*]//g' -e 's/([^()]*)//g' -e 's/[[A-z0-9!+]*]//g')"
+    romNameTrimmed="$(echo "$romNameTrimmed" | sed -e 's/ ([^()]*)//g' -e 's/ [[A-z0-9!+-]*]//g' -e 's/([^()]*)//g' -e 's/[[A-z0-9!+-]*]//g')"
     romNameTrimmed="${romNameTrimmed//" - "/"%20"}"
     romNameTrimmed="${romNameTrimmed/"-"/"%20"}"
     romNameTrimmed="${romNameTrimmed//" "/"%20"}"
@@ -425,37 +443,71 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
 	
 	else
 		rom_size=$(stat -c%s "$file")
-		url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=&systemeid=${ssSystemID}&romtype=rom&romnom=${romNameTrimmed}.zip&romtaille=${rom_size}"
-    	search_on_screenscraper
-    	
-    	# Don't check art if we didn't get screenscraper game ID
-        if ! [ "$gameIDSS" -eq "$gameIDSS" ] 2> /dev/null; then
+
+		# --- 1) PBP : exact search by serial number (from the embedded PARAM.SFO) ---
+		if [ -n "$pbpSerial" ]; then
+			pbpSerialDashed=$(echo "$pbpSerial" | sed -e 's/^\(.\{4\}\)\([0-9A-Z]\{3,6\}\)$/\1-\2/')
+			echo "Searching by serial : $pbpSerialDashed"
+			url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=&systemeid=${ssSystemID}&romtype=rom&romnom=${pbpSerialDashed}.zip&romtaille=${rom_size}&ssserial=${pbpSerialDashed}"
+			search_on_screenscraper
+		fi
+
+		# --- 2) PBP : search by the real game title (from the embedded PARAM.SFO) ---
+		if [ -z "$gameIDSS" ] && [ -n "$pbpTitle" ]; then
+			pbpTitleTrimmed="$(echo "$pbpTitle" | sed -e 's/ ([^()]*)//g' -e 's/ [[A-z0-9!+-]*]//g' -e 's/([^()]*)//g' -e 's/[[A-z0-9!+-]*]//g' -e 's/^ *//' -e 's/ *$//')"
+			pbpTitleTrimmed="${pbpTitleTrimmed//" - "/"%20"}"
+			pbpTitleTrimmed="${pbpTitleTrimmed/"-"/"%20"}"
+			pbpTitleTrimmed="${pbpTitleTrimmed//" "/"%20"}"
+			url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=&systemeid=${ssSystemID}&romtype=rom&romnom=${pbpTitleTrimmed}.zip&romtaille=${rom_size}"
+			search_on_screenscraper
+		fi
+
+		# --- 3) search by file name (skipped when a PBP title was already tried) ---
+		if [ -z "$gameIDSS" ] && { [ "$isPbp" != "1" ] || [ -z "$pbpTitle" ]; }; then
+			url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=&systemeid=${ssSystemID}&romtype=rom&romnom=${romNameTrimmed}.zip&romtaille=${rom_size}"
+			search_on_screenscraper
+		fi
+
+		# --- 4) last chance : rom checksum (pointless for PBP containers, skip them) ---
+		if [ -z "$gameIDSS" ] && [ "$isPbp" != "1" ]; then
 			# Last chance : we search thanks to rom checksum
 			MAX_FILE_SIZE_BYTES=52428800  #50MB
-			
+
 			if [ "$rom_size" -gt "$MAX_FILE_SIZE_BYTES" ]; then
 				echo -e "${RED}Rom is too big to make a checksum.${NONE}"
 				let Scrap_Fail++;
 				continue;
-				
+
 			else
 				echo -n "CRC check..."
 				CRC=$(xcrc "$file")
 				echo " $CRC"
 				# !!! systemid must not be specified, it impacts the search by CRC but not romtaille (must be > 2 however) or romnom. Most of other parameters than CRC are useless for the request but helps to fill SS database
-				url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=${CRC}&systemeid=&romtype=rom&romnom=${romNameTrimmed}.zip&romtaille=${rom_size}"  
+				url="https://www.screenscraper.fr/api2/jeuInfos.php?devid=${u#???}&devpassword=${p%??}&softname=onion&output=json&ssid=${userSS}&sspassword=${passSS}&crc=${CRC}&systemeid=&romtype=rom&romnom=${romNameTrimmed}.zip&romtaille=${rom_size}"
 				search_on_screenscraper
-				if ! [ "$gameIDSS" -eq "$gameIDSS" ] 2> /dev/null; then	
+				if [ -z "$gameIDSS" ]; then
 					echo -e "${RED}Failed to get game ID${NONE}"
 					let Scrap_Fail++;
 					continue;
 				fi
-				
+
 				RealgameName=$(echo "$api_result" | jq -r '.response.jeu.noms[0].text')
 				echo Real name found : "$RealgameName"
 			fi
+		fi
 
-        fi
+		# --- 5) PBP with no Screenscraper match : use the icon embedded in the file ---
+		if [ "$isPbp" = "1" ] && [ -z "$gameIDSS" ]; then
+			echo -n "No Screenscraper match, trying the PBP embedded icon... "
+			if pbpinfo -i "$file" "/mnt/SDCARD/Roms/$CurrentSystem/Imgs/$romNameNoExtension.png" 2>/dev/null; then
+				echo -e "${GREEN}Scraped from PBP metadata !${NONE}"
+				let Scrap_Success++;
+			else
+				echo -e "${RED}no embedded icon found${NONE}"
+				let Scrap_Fail++;
+			fi
+			continue;
+		fi
 		
         echo "gameID = $gameIDSS"
 


### PR DESCRIPTION
## Problem

PBP files embed a small icon that the scraper extracts as a fallback artwork (see the PBP support PR). Once such a low-resolution image exists, the scraper's "already Scraped" check skips the game forever, so higher quality Screenscraper boxart is never fetched.

## Solution

Adds a `DiscardEmbeddedArt` option (default **on**):

- Locally extracted art is registered in `Imgs/.pbp_local_art.txt` at extraction time.
- When the scraper meets a `.pbp` that has art **and** is in the registry, it discards the PNG and downloads the Screenscraper boxart instead.
- Art fetched by any scraper (Screenscraper, LaunchBox, Skraper.net, …) has no registry entry and is therefore never discarded — the option can only "downgrade" nothing.
- New toggle in Scraper → Configuration ("Toggle discard of embedded PBP art"), and a `DiscardEmbeddedArt` default in `config_repair.sh` so existing installs get it too.

CHD and all other formats are unaffected (they never produce embedded art).

## Testing

Device-tested on a Miyoo Mini: registry written by extraction, discarded on scrape, high quality boxart downloaded, registry entry removed. `sh -n` clean on all touched scripts.
